### PR TITLE
fix InvalidDateFormat error incase of OS LC_TIME setting

### DIFF
--- a/src/log_api.c
+++ b/src/log_api.c
@@ -2,6 +2,7 @@
 #include "log_api.h"
 #include <curl/curl.h>
 #include <string.h>
+#include <locale.h>
 #include "sds.h"
 #include "inner_log.h"
 
@@ -52,6 +53,12 @@ void get_now_time_str(char * buffer, int bufLen)
     struct tm * timeinfo;
     time (&rawtime);
     timeinfo = gmtime(&rawtime);
+    // make sure time_str is RFC822 format, or server return 400 (InvalidDateFormat)
+    char *time_locale = setlocale(LC_TIME, "en_US.UTF-8");
+    if(time_locale == NULL){
+        printf("error while set LC_TIME");
+    }
+
     strftime(buffer, bufLen, "%a, %d %b %Y %H:%M:%S GMT", timeinfo);
 }
 

--- a/src/log_api.c
+++ b/src/log_api.c
@@ -56,7 +56,7 @@ void get_now_time_str(char * buffer, int bufLen)
     // make sure time_str is RFC822 format, or server return 400 (InvalidDateFormat)
     char *time_locale = setlocale(LC_TIME, "en_US.UTF-8");
     if(time_locale == NULL){
-        printf("error while set LC_TIME");
+        printf("error while set LC_TIME to en_US.UTF-8");
     }
 
     strftime(buffer, bufLen, "%a, %d %b %Y %H:%M:%S GMT", timeinfo);


### PR DESCRIPTION
在部分操作系统（ubuntu18.04 LTS）上，因为`LC_TIME`的原因，导致日志上传失败
```
code : 400, error msg : {"errorCode":"InvalidRequestTime","errorMessage":"request time 五, 29 3月 2019 03:42:45 GMT not follow RFC822 spec"}
```
因此在调用`strftime`方法进行格式化前，设置`LC_TIME`