### PR TITLE
Add curl link option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 PROJECT(log_c_sdk)
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)  
+CMAKE_MINIMUM_REQUIRED(VERSION 3.13.5)
 
 set(CMAKE_VERSION 2.0.0)
 
@@ -37,16 +37,6 @@ ENDIF(ADD_LOG_KEY_VALUE_FUN)
 #curl-config
 FIND_PROGRAM(CURL_CONFIG_BIN NAMES curl-config)
   
-IF (CURL_CONFIG_BIN)
-    EXECUTE_PROCESS(
-        COMMAND ${CURL_CONFIG_BIN} --libs
-        OUTPUT_VARIABLE CURL_LIBRARIES
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-ELSE()
-    MESSAGE(FATAL_ERROR "Could not find curl-config")
-ENDIF()
-  
 # Compile and link lib_log_c_sdk
 include_directories(${CURL_INCLUDE_DIR})
 
@@ -54,6 +44,17 @@ aux_source_directory(src SRC_LIST)
 
 add_library(${CMAKE_PROJECT_NAME} SHARED ${SRC_LIST})
 add_library(${CMAKE_PROJECT_NAME}_static STATIC ${SRC_LIST})
+
+IF (CURL_CONFIG_BIN)
+    EXECUTE_PROCESS(
+        COMMAND ${CURL_CONFIG_BIN} --libs
+        OUTPUT_VARIABLE CURL_LIBRARIES
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "SHELL:${CURL_LIBRARIES}")
+ELSE()
+    MESSAGE(FATAL_ERROR "Could not find curl-config")
+ENDIF()
 
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES VERSION ${CMAKE_VERSION}  SOVERSION ${CMAKE_VERSION})
 


### PR DESCRIPTION
On a Mac, there is the following error when running `make`:
```
$ make
Scanning dependencies of target log_c_sdk
[  2%] Building C object CMakeFiles/log_c_sdk.dir/src/hmac-sha.o
[  4%] Building C object CMakeFiles/log_c_sdk.dir/src/inner_log.o
[  7%] Building C object CMakeFiles/log_c_sdk.dir/src/log_api.o
[  9%] Building C object CMakeFiles/log_c_sdk.dir/src/log_builder.o
[ 12%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_client.o
[ 14%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_common.o
[ 17%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_config.o
[ 19%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_manager.o
[ 21%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_sender.o
[ 24%] Building C object CMakeFiles/log_c_sdk.dir/src/log_queue.o
[ 26%] Building C object CMakeFiles/log_c_sdk.dir/src/log_util.o
[ 29%] Building C object CMakeFiles/log_c_sdk.dir/src/lz4.o
[ 31%] Building C object CMakeFiles/log_c_sdk.dir/src/md5.o
[ 34%] Building C object CMakeFiles/log_c_sdk.dir/src/sds.o
[ 36%] Building C object CMakeFiles/log_c_sdk.dir/src/sha1.o
[ 39%] Linking C shared library build/lib/liblog_c_sdk.dylib
Undefined symbols for architecture x86_64:
  "_curl_easy_cleanup", referenced from:
      _post_logs_from_lz4buf in log_api.o
  "_curl_easy_getinfo", referenced from:
      _post_logs_from_lz4buf in log_api.o
  "_curl_easy_init", referenced from:
      _post_logs_from_lz4buf in log_api.o
  "_curl_easy_perform", referenced from:
      _post_logs_from_lz4buf in log_api.o
  "_curl_easy_setopt", referenced from:
      _post_logs_from_lz4buf in log_api.o
  "_curl_easy_strerror", referenced from:
      _sls_log_init in log_api.o
      _post_logs_from_lz4buf in log_api.o
  "_curl_global_cleanup", referenced from:
      _sls_log_destroy in log_api.o
  "_curl_global_init", referenced from:
      _sls_log_init in log_api.o
  "_curl_slist_append", referenced from:
      _post_logs_from_lz4buf in log_api.o
  "_curl_slist_free_all", referenced from:
      _post_logs_from_lz4buf in log_api.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [build/lib/liblog_c_sdk.2.0.0.dylib] Error 1
make[1]: *** [CMakeFiles/log_c_sdk.dir/all] Error 2
make: *** [all] Error 2
```

Add the curl link option to CMake fixies this problem.