### PR TITLE
Fix compile and link errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 PROJECT(log_c_sdk)
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)  
+CMAKE_MINIMUM_REQUIRED(VERSION 3.13.5)  
 
 set(CMAKE_VERSION 2.0.0)
 
@@ -28,6 +28,11 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/build/${CMAKE_BUILD_TYPE}/bin)
 set(CMAKE_C_OUTPUT_EXTENSION_REPLACE 1)
 set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 
+aux_source_directory(src SRC_LIST)
+
+add_library(${CMAKE_PROJECT_NAME} SHARED ${SRC_LIST})
+add_library(${CMAKE_PROJECT_NAME}_static STATIC ${SRC_LIST})
+
 FIND_PROGRAM(APR_CONFIG_BIN NAMES apr-config apr-1-config PATHS /usr/bin /usr/local/bin /usr/local/apr/bin/)
 FIND_PROGRAM(APU_CONFIG_BIN NAMES apu-config apu-1-config PATHS /usr/bin /usr/local/bin /usr/local/apr/bin/)
 
@@ -47,6 +52,7 @@ IF (APR_CONFIG_BIN)
         OUTPUT_VARIABLE APR_LIBRARIES
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "SHELL:${APR_LIBRARIES}")
 ELSE()
     MESSAGE(FATAL_ERROR "Could not find apr-config/apr-1-config")
 ENDIF()
@@ -67,6 +73,7 @@ IF (APU_CONFIG_BIN)
         OUTPUT_VARIABLE APU_LIBRARIES
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "SHELL:${APU_LIBRARIES}")
 ELSE()
     MESSAGE(FATAL_ERROR "Could not find apu-config/apu-1-config")
 ENDIF()
@@ -80,20 +87,16 @@ IF (CURL_CONFIG_BIN)
         OUTPUT_VARIABLE CURL_LIBRARIES
         OUTPUT_STRIP_TRAILING_WHITESPACE
         )
+    target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "SHELL:${CURL_LIBRARIES}")
 ELSE()
     MESSAGE(FATAL_ERROR "Could not find curl-config")
 ENDIF()
-  
+
 # Compile and link lib_log_c_sdk
 include_directories(${APR_INCLUDE_DIR})
 include_directories(${APR_UTIL_INCLUDE_DIR})
 include_directories(${CURL_INCLUDE_DIR})
-
-aux_source_directory(src SRC_LIST)
-
-add_library(${CMAKE_PROJECT_NAME} SHARED ${SRC_LIST})
-add_library(${CMAKE_PROJECT_NAME}_static STATIC ${SRC_LIST})
-
+  
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES VERSION ${CMAKE_VERSION}  SOVERSION ${CMAKE_VERSION})
 
 file(GLOB HEADER_FILES src/*.h)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ LOG C SDK并没有带上这几个外部库，您需要确认这些库已经安�
  - 需要通过--with-apr指定apr安装目录，如果apr安装到系统目录下需要指定--with-apr=/usr/local/apr/
 
 
-##### CMake (建议2.6.0及以上版本)
+##### CMake (需要3.13.5及以上版本)
 
   请从[这里](https://cmake.org/download)下载，典型的安装方式如下：
 ```shell

--- a/src/aos_transport.c
+++ b/src/aos_transport.c
@@ -26,7 +26,7 @@ static void aos_init_curl_headers(aos_curl_http_transport_t *t)
     union aos_func_u func;
 
     if (t->req->method == HTTP_PUT || t->req->method == HTTP_POST) {
-        header = apr_psprintf(t->pool, "Content-Length: %" APR_INT64_T_FMT, t->req->body_len);
+        header = apr_psprintf(t->pool, "Content-Length: %" PRId64, t->req->body_len);
         t->headers = curl_slist_append(t->headers, header);
     }
 
@@ -243,7 +243,7 @@ size_t aos_curl_default_write_callback(char *ptr, size_t size, size_t nmemb, voi
 
     if (t->resp->type == BODY_IN_MEMORY && t->resp->body_len >= (int64_t)t->controller->options->max_memory_size) {
         t->controller->reason = apr_psprintf(t->pool,
-             "receive body too big, current body size: %" APR_INT64_T_FMT ", max memory size: %" APR_INT64_T_FMT,
+             "receive body too big, current body size: %" PRId64 ", max memory size: %" PRId64,
               t->resp->body_len, t->controller->options->max_memory_size);
         t->controller->error_code = AOSE_OVER_MEMORY;
         aos_error_log("error reason:%s, ", t->controller->reason);


### PR DESCRIPTION
Running make after running CMake, there is the following compile error:
```
$ make
Scanning dependencies of target log_c_sdk
[  1%] Building C object CMakeFiles/log_c_sdk.dir/src/aos_buf.o
[  3%] Building C object CMakeFiles/log_c_sdk.dir/src/aos_fstack.o
[  5%] Building C object CMakeFiles/log_c_sdk.dir/src/aos_http_io.o
[  7%] Building C object CMakeFiles/log_c_sdk.dir/src/aos_log.o
[  8%] Building C object CMakeFiles/log_c_sdk.dir/src/aos_status.o
[ 10%] Building C object CMakeFiles/log_c_sdk.dir/src/aos_string.o
[ 12%] Building C object CMakeFiles/log_c_sdk.dir/src/aos_transport.o
/Users/jing/code/xdf/sls/aliyun-log-c-sdk/src/aos_transport.c:29:77: error: format specifies type 'long' but the argument has type 'int64_t'
      (aka 'long long') [-Werror,-Wformat]
        header = apr_psprintf(t->pool, "Content-Length: %" APR_INT64_T_FMT, t->req->body_len);
                                                        ~~~~~~~~~~~~~~~~~~  ^~~~~~~~~~~~~~~~
/Users/jing/code/xdf/sls/aliyun-log-c-sdk/src/aos_transport.c:247:15: error: format specifies type 'long' but the argument has type 'int64_t'
      (aka 'long long') [-Werror,-Wformat]
              t->resp->body_len, t->controller->options->max_memory_size);
              ^~~~~~~~~~~~~~~~~
/Users/jing/code/xdf/sls/aliyun-log-c-sdk/src/aos_transport.c:247:34: error: format specifies type 'long' but the argument has type 'int64_t'
      (aka 'long long') [-Werror,-Wformat]
              t->resp->body_len, t->controller->options->max_memory_size);
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
3 errors generated.
make[2]: *** [CMakeFiles/log_c_sdk.dir/src/aos_transport.o] Error 1
make[1]: *** [CMakeFiles/log_c_sdk.dir/all] Error 2
make: *** [all] Error 2
```

After replacing `APR_INT64_T_FMT` with `PRId64` to fix the above error, there is the following linking error:

```
$ make
Scanning dependencies of target log_c_sdk
[  1%] Building C object CMakeFiles/log_c_sdk.dir/src/aos_transport.o
[  3%] Building C object CMakeFiles/log_c_sdk.dir/src/aos_util.o
[  5%] Building C object CMakeFiles/log_c_sdk.dir/src/cJSON.o
[  7%] Building C object CMakeFiles/log_c_sdk.dir/src/log_api.o
[  8%] Building C object CMakeFiles/log_c_sdk.dir/src/log_auth.o
[ 10%] Building C object CMakeFiles/log_c_sdk.dir/src/log_builder.o
[ 12%] Building C object CMakeFiles/log_c_sdk.dir/src/log_define.o
[ 14%] Building C object CMakeFiles/log_c_sdk.dir/src/log_http_cont.o
[ 15%] Building C object CMakeFiles/log_c_sdk.dir/src/log_logstores.pb-c.o
[ 17%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_client.o
[ 19%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_common.o
[ 21%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_config.o
[ 22%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_debug_flusher.o
[ 24%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_manager.o
[ 26%] Building C object CMakeFiles/log_c_sdk.dir/src/log_producer_sender.o
[ 28%] Building C object CMakeFiles/log_c_sdk.dir/src/log_util.o
[ 29%] Building C object CMakeFiles/log_c_sdk.dir/src/lz4.o
[ 31%] Building C object CMakeFiles/log_c_sdk.dir/src/protobuf-c.o
[ 33%] Linking C shared library build/lib/liblog_c_sdk.dylib
Undefined symbols for architecture x86_64:
  "_apr_md5_final", referenced from:
      _aos_md5 in aos_util.o
      __get_lz4_buf_md5 in log_http_cont.o
      __get_pack_id in log_producer_manager.o
  "_apr_md5_init", referenced from:
      _aos_md5 in aos_util.o
      __get_lz4_buf_md5 in log_http_cont.o
      __get_pack_id in log_producer_manager.o
  "_apr_md5_update", referenced from:
      _aos_md5 in aos_util.o
      __get_lz4_buf_md5 in log_http_cont.o
      __get_pack_id in log_producer_manager.o
  "_apr_queue_create", referenced from:
      __create_log_producer_manager in log_producer_manager.o
  "_apr_queue_interrupt_all", referenced from:
      _destroy_log_producer_manager in log_producer_manager.o
  "_apr_queue_size", referenced from:
      _destroy_log_producer_manager in log_producer_manager.o
  "_apr_queue_term", referenced from:
      _destroy_log_producer_manager in log_producer_manager.o
  "_apr_queue_trypop", referenced from:
      _log_producer_flush_thread in log_producer_manager.o
  "_apr_queue_trypush", referenced from:
      __try_flush_loggroup in log_producer_manager.o
      __push_last_loggroup in log_producer_manager.o
      _log_producer_manager_add_log_end in log_producer_manager.o
  "_apr_sha1_final", referenced from:
      _HMAC_SHA1 in aos_util.o
  "_apr_sha1_init", referenced from:
      _HMAC_SHA1 in aos_util.o
  "_apr_sha1_update", referenced from:
      _HMAC_SHA1 in aos_util.o
  "_apr_thread_pool_create", referenced from:
      _create_log_producer_sender in log_producer_sender.o
  "_apr_thread_pool_destroy", referenced from:
      _destroy_log_producer_sender in log_producer_sender.o
  "_apr_thread_pool_push", referenced from:
      _log_producer_send_data in log_producer_sender.o
  "_apr_thread_pool_tasks_count", referenced from:
      _destroy_log_producer_sender in log_producer_sender.o
  "_apr_thread_pool_thread_max_set", referenced from:
      _destroy_log_producer_sender in log_producer_sender.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [build/lib/liblog_c_sdk.2.0.0.dylib] Error 1
make[1]: *** [CMakeFiles/log_c_sdk.dir/all] Error 2
make: *** [all] Error 2
```

After adding ADD_LINK_OPTIONS to fix the above error,  the SDK can be successfully built. But there is still errors when building the benchmark:

```
$ make
[  1%] Linking C shared library build/lib/liblog_c_sdk.dylib
[ 43%] Built target log_c_sdk
Scanning dependencies of target log_c_sdk_static
[ 45%] Building C object CMakeFiles/log_c_sdk_static.dir/src/aos_buf.o
[ 47%] Building C object CMakeFiles/log_c_sdk_static.dir/src/aos_fstack.o
[ 49%] Building C object CMakeFiles/log_c_sdk_static.dir/src/aos_http_io.o
[ 50%] Building C object CMakeFiles/log_c_sdk_static.dir/src/aos_log.o
[ 52%] Building C object CMakeFiles/log_c_sdk_static.dir/src/aos_status.o
[ 54%] Building C object CMakeFiles/log_c_sdk_static.dir/src/aos_string.o
[ 56%] Building C object CMakeFiles/log_c_sdk_static.dir/src/aos_transport.o
[ 57%] Building C object CMakeFiles/log_c_sdk_static.dir/src/aos_util.o
[ 59%] Building C object CMakeFiles/log_c_sdk_static.dir/src/cJSON.o
[ 61%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_api.o
[ 63%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_auth.o
[ 64%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_builder.o
[ 66%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_define.o
[ 68%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_http_cont.o
[ 70%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_logstores.pb-c.o
[ 71%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_producer_client.o
[ 73%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_producer_common.o
[ 75%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_producer_config.o
[ 77%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_producer_debug_flusher.o
[ 78%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_producer_manager.o
[ 80%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_producer_sender.o
[ 82%] Building C object CMakeFiles/log_c_sdk_static.dir/src/log_util.o
[ 84%] Building C object CMakeFiles/log_c_sdk_static.dir/src/lz4.o
[ 85%] Building C object CMakeFiles/log_c_sdk_static.dir/src/protobuf-c.o
[ 87%] Linking C static library build/lib/liblog_c_sdk_static.a
[ 87%] Built target log_c_sdk_static
Scanning dependencies of target log_producer_benchmark
[ 89%] Building C object sample/CMakeFiles/log_producer_benchmark.dir/log_producer_benchmark.o
[ 91%] Linking C executable ../build/bin/log_producer_benchmark
ld: cannot link directly with dylib/framework, your binary is not an allowed client of /usr/lib/libcrypto.dylib for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [build/bin/log_producer_benchmark] Error 1
make[1]: *** [sample/CMakeFiles/log_producer_benchmark.dir/all] Error 2
make: *** [all] Error 2
```

This PR fixes the first two errors.
