### PR TITLE
fix crash when post_logs_from_lz4buf option param set null

### DIFF
--- a/sample/log_post_logs_sample.c
+++ b/sample/log_post_logs_sample.c
@@ -85,10 +85,18 @@ void post_logs_with_http_cont_lz4_log_option()
             printf("serialize_to_proto_buf_with_malloc_lz4 failed\n");
             exit(1);
         }
-        post_log_result * rst = post_logs_from_lz4buf(LOG_ENDPOINT, ACCESS_KEY_ID,
+		
+		log_post_option option{0};
+		option.compress_type = 1;
+		option.connect_timeout = 0;
+		option.interface = nullptr;
+		option.ntp_time_offset = 0;
+		option.operation_timeout = 0;
+		
+		post_log_result * rst = post_logs_from_lz4buf(LOG_ENDPOINT, ACCESS_KEY_ID,
                                                  ACCESS_KEY_SECRET, NULL,
                                                  PROJECT_NAME, LOGSTORE_NAME,
-                                                 pLZ4Buf, NULL);
+                                                 pLZ4Buf, &option);
         printf("result %d %d \n", i, rst->statusCode);
         if (rst->errorMessage != NULL)
         {


### PR DESCRIPTION
fix sample/log_post_logs_sample.c crash  when post_logs_from_lz4buf option param set null