### PR TITLE
win32 not gmtime_r function use gmtime_s function

### DIFF
--- a/src/log_api.c
+++ b/src/log_api.c
@@ -168,7 +168,12 @@ void get_now_time_str(char * buffer, int bufLen, int timeOffset)
     {
       rawtime += timeOffset;
     }
+    //gmtime_r(&rawtime, &timeinfo);
+#ifdef WIN32
+    gmtime_s(&timeinfo, &rawtime);
+#else
     gmtime_r(&rawtime, &timeinfo);
+#endif
     sls_rfc822_date(buffer, &timeinfo);
 }
 


### PR DESCRIPTION
win32 没有gmtime_r函数使用gmtime_s函数，但是参数顺序互换；