### PR TITLE
fix network panic log

### DIFF
--- a/src/log_producer_sender.c
+++ b/src/log_producer_sender.c
@@ -316,25 +316,14 @@ int32_t log_producer_on_send_done(log_producer_send_param * send_param, post_log
                 }
 #endif
             }
-            if (result->errorMessage != NULL)
-            {
-                aos_warn_log("send network error, project : %s, logstore : %s, buffer len : %d, raw len : %d, code : %d, error msg : %s",
-                             send_param->producer_config->project,
-                             send_param->producer_config->logstore,
-                             (int)send_param->log_buf->length,
-                             (int)send_param->log_buf->raw_length,
-                             result->statusCode,
-                             result->errorMessage);
-            }
-            else
-            {
-                aos_warn_log("send network error, project : %s, logstore : %s, buffer len : %d, raw len : %d, code : %d",
-                             send_param->producer_config->project,
-                             send_param->producer_config->logstore,
-                             (int)send_param->log_buf->length,
-                             (int)send_param->log_buf->raw_length,
-                             result->statusCode);
-            }
+            aos_warn_log(
+                "send network error, project : %s, logstore : %s, buffer len : "
+                "%d, raw len : %d, code : %d, error msg : %s",
+                send_param->producer_config->project,
+                send_param->producer_config->logstore,
+                (int)send_param->log_buf->length,
+                (int)send_param->log_buf->raw_length, result->statusCode,
+                result->errorMessage == NULL ? "" : result->errorMessage);
             return error_info->last_sleep_ms;
         default:
             // discard data

--- a/src/log_producer_sender.c
+++ b/src/log_producer_sender.c
@@ -316,13 +316,25 @@ int32_t log_producer_on_send_done(log_producer_send_param * send_param, post_log
                 }
 #endif
             }
-            aos_warn_log("send network error, project : %s, logstore : %s, buffer len : %d, raw len : %d, code : %d, error msg : %s",
-                         send_param->producer_config->project,
-                         send_param->producer_config->logstore,
-                         (int)send_param->log_buf->length,
-                         (int)send_param->log_buf->raw_length,
-                         result->statusCode,
-                         result->errorMessage);
+            if (result->errorMessage != NULL)
+            {
+                aos_warn_log("send network error, project : %s, logstore : %s, buffer len : %d, raw len : %d, code : %d, error msg : %s",
+                             send_param->producer_config->project,
+                             send_param->producer_config->logstore,
+                             (int)send_param->log_buf->length,
+                             (int)send_param->log_buf->raw_length,
+                             result->statusCode,
+                             result->errorMessage);
+            }
+            else
+            {
+                aos_warn_log("send network error, project : %s, logstore : %s, buffer len : %d, raw len : %d, code : %d",
+                             send_param->producer_config->project,
+                             send_param->producer_config->logstore,
+                             (int)send_param->log_buf->length,
+                             (int)send_param->log_buf->raw_length,
+                             result->statusCode);
+            }
             return error_info->last_sleep_ms;
         default:
             // discard data


### PR DESCRIPTION
(gdb) bt
#0 0xb6bf797c in aos_log_format () from /usr/lib/liboss_c_sdk.so.3.0.0
#1 0xb6a7acd8 in log_producer_on_send_done ()
from /usr/lib/liblog_c_sdk.so.3.0.0
#2 0xb6a7a870 in log_producer_send_fun () from /usr/lib/liblog_c_sdk.so.3.0.0
#3 0xb6a7a37c in log_producer_send_thread