### PR TITLE
fix: persistent build failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,6 @@ sample/log_c_sdk_sample.cbp
 # IDEA
 .idea
 
+cmake-build-debug
+
 

--- a/src/log_api.c
+++ b/src/log_api.c
@@ -15,7 +15,7 @@ unsigned int LOG_GET_TIME();
 void log_http_inject_headers(log_producer_config *config, char **src_headers, int src_count, char **dest_headers, int *dest_count);
 void log_http_release_inject_headers(log_producer_config *config, char **dest_headers, int dest_count);
 
-log_status_t sls_log_init(int32_t log_global_flag)
+log_status_t sls_log_init()
 {
 #if 0
     CURLcode ecode;

--- a/src/log_producer_manager.c
+++ b/src/log_producer_manager.c
@@ -49,8 +49,7 @@ char * _get_pack_id(const char * configName, const char * ip)
     _generate_pack_id_timestamp(&timestamp);
 
     char *prefix = (char *) malloc(100 * sizeof (char));
-    strcpy(prefix, configName);
-    sprintf(prefix, "%s%ld", prefix, timestamp);
+    sprintf(prefix, "%s%ld", configName, timestamp);
 
     unsigned char md5Buf[16];
     mbedtls_md5((const unsigned char *)prefix, strlen(prefix), md5Buf);


### PR DESCRIPTION
1. fix: remove a useless param of func sls_log_init
2. fix: error: 'sprintf' argument 3 overlaps destination object 'prefix'
![image](https://github.com/aliyun/aliyun-log-c-sdk/assets/11848989/e159569d-609d-4782-be79-50f958ee6236)
3. feat: add `cmake-build-debug` into `.gitignore`
