### PR TITLE
feat: add API-Key authentication mode (Bearer token)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 0.2.0
 - 新增 API-Key 鉴权模式，使用 `Bearer <api-key>` 作为 Authorization Header，与 AccessKey 模式互斥，强制 HTTPS
 - 新增 `log_producer_config_set_api_key()` 接口
+- 新增线程安全的 `log_producer_config_reset_api_key()` 轮转接口
 - 新增 `AUTH_VERSION_APIKEY` 认证版本枚举
 
 ## 0.1.0 (2018-02-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 # Change Log (Producer Lite)
+## 0.2.0
+- 新增 API-Key 鉴权模式，使用 `Bearer <api-key>` 作为 Authorization Header，与 AccessKey 模式互斥，强制 HTTPS
+- 新增 `log_producer_config_set_api_key()` 接口
+- 新增 `AUTH_VERSION_APIKEY` 认证版本枚举
+
 ## 0.1.0 (2018-02-27)
 Producer Lite版本发布

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,3 +81,9 @@ INSTALL(FILES
   DESTINATION include/log_c_sdk)
 
 add_subdirectory(sample)
+
+option(BUILD_TESTING "Build SDK tests" OFF)
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/docs/cn/ApiKeyAuth.md
+++ b/docs/cn/ApiKeyAuth.md
@@ -7,7 +7,7 @@ API-Key 鉴权模式允许用户使用 API-Key 进行身份认证，无需 Acces
 - **HTTPS 强制**：API-Key 模式**必须**使用 HTTPS，否则 producer 创建会失败
 - **与 AK 模式互斥**：不能同时设置 API-Key 和 AccessKey ID / AccessKey Secret，否则 producer 创建会失败
 - **与动态凭证互斥**：不能同时设置 API-Key 和 credentials callback
-- **不支持轮转**：API-Key 模式不支持动态凭证轮转
+- **线程安全轮转**：producer 启动后调用 `log_producer_config_reset_api_key()` 更新 API-Key
 
 ## 使用方式
 
@@ -34,6 +34,10 @@ log_producer_client * client = get_log_producer_client(producer, NULL);
 
 // 发送日志
 log_producer_client_add_log(client, 4, "key1", "value1", "key2", "value2");
+
+// producer 运行期间线程安全地轮转 API-Key。正在发送的请求继续使用旧快照，
+// 后续请求使用新的 API-Key。
+log_producer_config_reset_api_key(config, "your-new-api-key");
 
 // 4. 清理
 destroy_log_producer(producer);

--- a/docs/cn/ApiKeyAuth.md
+++ b/docs/cn/ApiKeyAuth.md
@@ -1,0 +1,51 @@
+# API-Key 鉴权使用说明
+
+API-Key 鉴权模式允许用户使用 API-Key 进行身份认证，无需 AccessKey ID / AccessKey Secret，无需签名计算。SDK 会在 Authorization Header 中携带 `Bearer <api-key>` 进行认证。
+
+## 约束
+
+- **HTTPS 强制**：API-Key 模式**必须**使用 HTTPS，否则 producer 创建会失败
+- **与 AK 模式互斥**：不能同时设置 API-Key 和 AccessKey ID / AccessKey Secret，否则 producer 创建会失败
+- **与动态凭证互斥**：不能同时设置 API-Key 和 credentials callback
+- **不支持轮转**：API-Key 模式不支持动态凭证轮转
+
+## 使用方式
+
+```c
+#include "log_api.h"
+#include "log_producer_config.h"
+#include "log_producer_client.h"
+
+// 1. 创建 producer 配置
+log_producer_config * config = create_log_producer_config();
+
+// endpoint 必须以 "https://" 开头
+log_producer_config_set_endpoint(config, "https://cn-hangzhou.log.aliyuncs.com");
+log_producer_config_set_project(config, "my-project");
+log_producer_config_set_logstore(config, "my-logstore");
+
+// 2. 设置 API-Key（会自动设置 authVersion = AUTH_VERSION_APIKEY）
+//    注意：不要再调用 log_producer_config_set_access_id / set_access_key
+log_producer_config_set_api_key(config, "your-api-key");
+
+// 3. 创建 producer 并使用
+log_producer * producer = create_log_producer(config, NULL);
+log_producer_client * client = get_log_producer_client(producer, NULL);
+
+// 发送日志
+log_producer_client_add_log(client, 4, "key1", "value1", "key2", "value2");
+
+// 4. 清理
+destroy_log_producer(producer);
+```
+
+完整示例可参见 [log_apikey_sample.c](../../sample/log_apikey_sample.c)
+
+## 常见错误
+
+| 错误信息 | 原因 | 解决方法 |
+|---------|------|---------|
+| `api-key mode requires HTTPS` | 未使用 HTTPS | endpoint 以 `https://` 开头，或调用 `log_producer_config_set_using_http(config, 1)` |
+| `api-key mode is mutually exclusive with access-key mode` | 同时设置了 API-Key 和 AccessKey | 只使用其中一种鉴权方式 |
+| `api-key mode does not support credentials callback` | 同时设置了 API-Key 和动态凭证回调 | API-Key 模式下不要设置 credentials callback |
+| `api-key mode requires a non-empty api-key` | API-Key 为空 | 传入有效的 API-Key 字符串 |

--- a/docs/en/ApiKeyAuth.md
+++ b/docs/en/ApiKeyAuth.md
@@ -1,0 +1,51 @@
+# API-Key Authentication Guide
+
+The API-Key authentication mode allows users to authenticate using an API-Key without AccessKey ID / AccessKey Secret and without signature calculation. The SDK sends `Bearer <api-key>` in the Authorization header for authentication.
+
+## Constraints
+
+- **HTTPS Required**: API-Key mode **must** use HTTPS; otherwise producer creation will fail
+- **Mutually Exclusive with AK Mode**: Cannot set both API-Key and AccessKey ID / AccessKey Secret simultaneously; otherwise producer creation will fail
+- **Mutually Exclusive with Dynamic Credentials**: Cannot set both API-Key and credentials callback
+- **No Rotation Support**: API-Key mode does not support dynamic credential rotation
+
+## Usage
+
+```c
+#include "log_api.h"
+#include "log_producer_config.h"
+#include "log_producer_client.h"
+
+// 1. Create producer config
+log_producer_config * config = create_log_producer_config();
+
+// Endpoint must start with "https://"
+log_producer_config_set_endpoint(config, "https://cn-hangzhou.log.aliyuncs.com");
+log_producer_config_set_project(config, "my-project");
+log_producer_config_set_logstore(config, "my-logstore");
+
+// 2. Set API-Key (automatically sets authVersion = AUTH_VERSION_APIKEY)
+//    Note: Do NOT call log_producer_config_set_access_id / set_access_key
+log_producer_config_set_api_key(config, "your-api-key");
+
+// 3. Create producer and use it
+log_producer * producer = create_log_producer(config, NULL);
+log_producer_client * client = get_log_producer_client(producer, NULL);
+
+// Send logs
+log_producer_client_add_log(client, 4, "key1", "value1", "key2", "value2");
+
+// 4. Cleanup
+destroy_log_producer(producer);
+```
+
+See [log_apikey_sample.c](../../sample/log_apikey_sample.c) for a complete example.
+
+## Common Errors
+
+| Error Message | Cause | Solution |
+|--------------|-------|----------|
+| `api-key mode requires HTTPS` | HTTPS not used | Ensure the endpoint starts with `https://`, or call `log_producer_config_set_using_http(config, 1)` |
+| `api-key mode is mutually exclusive with access-key mode` | Both API-Key and AccessKey are set | Use only one authentication method |
+| `api-key mode does not support credentials callback` | Both API-Key and credentials callback are set | Do not set credentials callback in API-Key mode |
+| `api-key mode requires a non-empty api-key` | API-Key is empty | Provide a valid API-Key string |

--- a/docs/en/ApiKeyAuth.md
+++ b/docs/en/ApiKeyAuth.md
@@ -7,7 +7,7 @@ The API-Key authentication mode allows users to authenticate using an API-Key wi
 - **HTTPS Required**: API-Key mode **must** use HTTPS; otherwise producer creation will fail
 - **Mutually Exclusive with AK Mode**: Cannot set both API-Key and AccessKey ID / AccessKey Secret simultaneously; otherwise producer creation will fail
 - **Mutually Exclusive with Dynamic Credentials**: Cannot set both API-Key and credentials callback
-- **No Rotation Support**: API-Key mode does not support dynamic credential rotation
+- **Thread-safe Rotation**: Use `log_producer_config_reset_api_key()` to rotate the key after the producer starts
 
 ## Usage
 
@@ -34,6 +34,10 @@ log_producer_client * client = get_log_producer_client(producer, NULL);
 
 // Send logs
 log_producer_client_add_log(client, 4, "key1", "value1", "key2", "value2");
+
+// Rotate the API-Key while the producer is running. In-flight requests keep
+// using their request-scoped snapshot; subsequent requests use the new key.
+log_producer_config_reset_api_key(config, "your-new-api-key");
 
 // 4. Cleanup
 destroy_log_producer(producer);

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -14,6 +14,8 @@ set(PRODUCER_FRAME_SOURCE_FILES video_frame_producer_sample.c)
 
 set(PRODUCER_DYNAMIC_CREDENTAILS_SOURCE_FILES log_dynamic_credentials_sample.c)
 
+set(PRODUCER_APIKEY_SOURCE_FILES log_apikey_sample.c)
+
 include_directories (${CURL_INCLUDE_DIR})
 include_directories ("${CMAKE_SOURCE_DIR}/src")
 
@@ -46,3 +48,4 @@ _TARGET_SAMPLE_LIBRARIES(log_producer_benchmark "${PRODUCER_BENCHMARK_SOURCE_FIL
 
 _TARGET_SAMPLE_LIBRARIES(video_frame_producer_sample "${PRODUCER_FRAME_SOURCE_FILES}")
 _TARGET_SAMPLE_LIBRARIES(dynamic_credentials_sample "${PRODUCER_DYNAMIC_CREDENTAILS_SOURCE_FILES}")
+_TARGET_SAMPLE_LIBRARIES(apikey_sample "${PRODUCER_APIKEY_SOURCE_FILES}")

--- a/sample/log_apikey_sample.c
+++ b/sample/log_apikey_sample.c
@@ -1,0 +1,114 @@
+#include "log_api.h"
+#include "log_producer_config.h"
+#include "log_producer_client.h"
+
+void on_log_send_done(const char * config_name, log_producer_result result, size_t log_bytes, size_t compressed_bytes, const char * req_id, const char * message, const unsigned char * raw_buffer)
+{
+    if (result == LOG_PRODUCER_OK)
+    {
+        if (req_id == NULL)
+        {
+            req_id = "";
+        }
+        printf("send success, config : %s, result : %d, log bytes : %d, compressed bytes : %d, request id : %s\n",
+               config_name, (result),
+               (int)log_bytes, (int)compressed_bytes, req_id);
+    }
+    else
+    {
+        if (message == NULL)
+        {
+            message = "";
+        }
+        if (req_id == NULL)
+        {
+            req_id = "";
+        }
+        printf("send fail, config : %s, result : %d, log bytes : %d, compressed bytes : %d, request id : %s, error message : %s\n",
+               config_name, (result),
+               (int)log_bytes, (int)compressed_bytes, req_id, message);
+    }
+}
+
+void log_producer_post_logs()
+{
+    if (log_producer_env_init(LOG_GLOBAL_ALL) != LOG_PRODUCER_OK) {
+        exit(1);
+    }
+
+    log_producer_config * config = create_log_producer_config();
+
+    // endpoint must start with "https://" for API-Key mode
+    // endpoint list: https://help.aliyun.com/document_detail/29008.html
+    log_producer_config_set_endpoint(config, "https://your-endpoint.log.aliyuncs.com");
+    log_producer_config_set_project(config, "your-project");
+    log_producer_config_set_logstore(config, "your-logstore");
+
+    // set API-Key (this automatically sets authVersion to AUTH_VERSION_APIKEY)
+    // API-Key mode is mutually exclusive with AccessKey mode
+    // do NOT call log_producer_config_set_access_id / set_access_key when using API-Key
+    log_producer_config_set_api_key(config, "your-api-key");
+
+    // optional: set topic and tags
+    log_producer_config_set_topic(config, "test_topic");
+    log_producer_config_add_tag(config, "tag_1", "val_1");
+
+    // set resource params
+    log_producer_config_set_packet_log_bytes(config, 4*1024*1024);
+    log_producer_config_set_packet_log_count(config, 4096);
+    log_producer_config_set_packet_timeout(config, 3000);
+    log_producer_config_set_max_buffer_limit(config, 64*1024*1024);
+
+    // set send thread count
+    log_producer_config_set_send_thread_count(config, 4);
+
+    log_producer * producer = create_log_producer(config, on_log_send_done);
+    if (producer == NULL)
+    {
+        printf("create log producer by config fail \n");
+        exit(1);
+    }
+
+    log_producer_client * client = get_log_producer_client(producer, NULL);
+    if (client == NULL)
+    {
+        printf("create log producer client by config fail \n");
+        exit(1);
+    }
+
+    int i = 0;
+    for (; i < 10; ++i)
+    {
+        char indexStr[32];
+        sprintf(indexStr, "%d", i);
+        log_producer_client_add_log(client, 20, "content_key_1", "1abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+",
+                                    "content_key_2", "2abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+",
+                                    "content_key_3", "3abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+",
+                                    "content_key_4", "4abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+",
+                                    "content_key_5", "5abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+",
+                                    "content_key_6", "6abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+",
+                                    "content_key_7", "7abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+",
+                                    "content_key_8", "8abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+",
+                                    "content_key_9", "9abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+",
+                                    "index", indexStr);
+
+        log_producer_result rst = log_producer_client_add_log(client, 8, "LogHub", "Real-time log collection and consumption",
+                          "Search/Analytics", "Query and real-time analysis",
+                          "Visualized", "dashboard and report functions",
+                          "Interconnection", "Grafana and JDBC/SQL92");
+        if (rst != LOG_PRODUCER_OK)
+        {
+            printf("add log error %d \n", rst);
+        }
+    }
+
+    destroy_log_producer(producer);
+
+    log_producer_env_destroy();
+}
+
+int main(int argc, char *argv[])
+{
+    log_producer_post_logs();
+    return 0;
+}

--- a/src/log_api.c
+++ b/src/log_api.c
@@ -240,7 +240,45 @@ post_log_result * post_logs_from_lz4buf(const char *endpoint, const char * acces
             aos_error_log("unsuported compresstype %d", option->compress_type);
         }
 
-        if (version == AUTH_VERSION_4)
+        if (version == AUTH_VERSION_APIKEY)
+        {
+            // API-Key mode: basic headers + Bearer token, no signature needed
+            headers=curl_slist_append(headers, "Content-Type:application/x-protobuf");
+            headers=curl_slist_append(headers, "x-log-apiversion:0.6.0");
+
+            sds headerHost = sdsnewEmpty(128);
+            headerHost = sdscatprintf(headerHost, "Host:%s.%s", project, endpoint);
+            headers=curl_slist_append(headers, headerHost);
+
+            sds headerLen = sdsnewEmpty(64);
+            headerLen = sdscatprintf(headerLen, "Content-Length:%d", (int)buffer->length);
+            headers=curl_slist_append(headers, headerLen);
+
+            sds headerRawLen = sdsnewEmpty(64);
+            headerRawLen = sdscatprintf(headerRawLen, "x-log-bodyrawsize:%d", (int)buffer->raw_length);
+            headers=curl_slist_append(headers, headerRawLen);
+
+            sds headerTime = sdsnew("Date:");
+            headerTime = sdscat(headerTime, nowTime);
+            headers=curl_slist_append(headers, headerTime);
+
+            sds headerMD5 = sdsnew("Content-MD5:");
+            headerMD5 = sdscat(headerMD5, md5Buf);
+            headers=curl_slist_append(headers, headerMD5);
+
+            // Authorization: Bearer <api-key>
+            sds headerAuth = sdsnewEmpty(256);
+            headerAuth = sdscatprintf(headerAuth, "Authorization:Bearer %s", accesskeyId);
+            headers=curl_slist_append(headers, headerAuth);
+
+            sdsfree(headerHost);
+            sdsfree(headerLen);
+            sdsfree(headerRawLen);
+            sdsfree(headerTime);
+            sdsfree(headerMD5);
+            sdsfree(headerAuth);
+        }
+        else if (version == AUTH_VERSION_4)
         {
             sds headerRawLen = sdsnewEmpty(64);
             headerRawLen = sdscatprintf(headerRawLen, "x-log-bodyrawsize:%d", (int)buffer->raw_length);

--- a/src/log_define.h
+++ b/src/log_define.h
@@ -36,7 +36,7 @@ enum _auth_version
 {
     AUTH_VERSION_1 = 1,
     AUTH_VERSION_4,
-    AUTH_VERSION_APIKEY   // API-Key Bearer token 鉴权
+    AUTH_VERSION_APIKEY   // API-Key Bearer token auth
 };
 
 typedef enum _auth_version auth_version;

--- a/src/log_define.h
+++ b/src/log_define.h
@@ -35,7 +35,8 @@ typedef struct _post_log_result post_log_result;
 enum _auth_version
 {
     AUTH_VERSION_1 = 1,
-    AUTH_VERSION_4
+    AUTH_VERSION_4,
+    AUTH_VERSION_APIKEY   // API-Key Bearer token 鉴权
 };
 
 typedef enum _auth_version auth_version;

--- a/src/log_producer_config.c
+++ b/src/log_producer_config.c
@@ -47,7 +47,6 @@ log_producer_config * create_log_producer_config()
     _set_default_producer_config(pConfig);
     pConfig->authVersion = AUTH_VERSION_1;
     pConfig->region = NULL;
-    pConfig->securityTokenLock = CreateCriticalSection();
     return pConfig;
 }
 
@@ -565,6 +564,10 @@ void log_producer_config_set_api_key(log_producer_config * config, const char * 
     {
         return;
     }
+    if (config->securityTokenLock == NULL)
+    {
+        config->securityTokenLock = CreateCriticalSection();
+    }
     CS_ENTER(config->securityTokenLock);
     _copy_config_string(api_key, &config->apiKey);
     config->authVersion = AUTH_VERSION_APIKEY;
@@ -575,6 +578,11 @@ void log_producer_config_reset_api_key(log_producer_config * config, const char 
 {
     if (config == NULL || api_key == NULL || api_key[0] == '\0')
     {
+        return;
+    }
+    if (config->securityTokenLock == NULL)
+    {
+        aos_error_log("reset api-key requires initialized API-Key mode");
         return;
     }
     CS_ENTER(config->securityTokenLock);
@@ -592,6 +600,11 @@ void log_producer_config_get_api_key(log_producer_config * config, char ** api_k
 {
     if (config == NULL || api_key == NULL)
     {
+        return;
+    }
+    if (config->securityTokenLock == NULL)
+    {
+        _copy_config_string(config->apiKey, api_key);
         return;
     }
     CS_ENTER(config->securityTokenLock);

--- a/src/log_producer_config.c
+++ b/src/log_producer_config.c
@@ -107,6 +107,10 @@ void destroy_log_producer_config(log_producer_config * pConfig)
         }
         free(pConfig->tags);
     }
+    if (pConfig->apiKey != NULL)
+    {
+        sdsfree(pConfig->apiKey);
+    }
     if (pConfig->region != NULL)
     {
         sdsfree(pConfig->region);
@@ -400,15 +404,50 @@ int log_producer_config_is_valid(log_producer_config * config)
         aos_error_log("invalid producer config destination params");
         return 0;
     }
-    // If credentials callback is set, we don't need static accessKey
-    if (config->credentials_callback == NULL)
+
+    // API-Key mode validation
+    if (config->authVersion == AUTH_VERSION_APIKEY)
     {
-        if (config->accessKey == NULL || config->accessKeyId == NULL)
+        if (config->accessKeyId != NULL || config->accessKey != NULL)
         {
-            aos_error_log("invalid producer config authority params");
+            aos_error_log("api-key mode is mutually exclusive with access-key mode");
+            return 0;
+        }
+        if (config->credentials_callback != NULL)
+        {
+            aos_error_log("api-key mode does not support credentials callback");
+            return 0;
+        }
+        if (config->using_https != 1)
+        {
+            aos_error_log("api-key mode requires HTTPS");
+            return 0;
+        }
+        if (config->apiKey == NULL || strlen(config->apiKey) == 0)
+        {
+            aos_error_log("api-key mode requires a non-empty api-key");
             return 0;
         }
     }
+    else
+    {
+        // AK mode should not have apiKey set
+        if (config->apiKey != NULL)
+        {
+            aos_error_log("apiKey is set but authVersion is not AUTH_VERSION_APIKEY, conflict");
+            return 0;
+        }
+        // If credentials callback is set, we don't need static accessKey
+        if (config->credentials_callback == NULL)
+        {
+            if (config->accessKey == NULL || config->accessKeyId == NULL)
+            {
+                aos_error_log("invalid producer config authority params");
+                return 0;
+            }
+        }
+    }
+
     if (config->packageTimeoutInMS < 0 || config->maxBufferBytes < 0 || config->logCountPerPackage < 0 || config->logBytesPerPackage < 0)
     {
         aos_error_log("invalid producer config log merge and buffer params");
@@ -517,4 +556,14 @@ void log_producer_config_set_credentials_userdata(log_producer_config* config, v
         return;
     }
     config->credentials_userdata = userdata;
+}
+
+void log_producer_config_set_api_key(log_producer_config * config, const char * api_key)
+{
+    if (config == NULL || api_key == NULL)
+    {
+        return;
+    }
+    _copy_config_string(api_key, &config->apiKey);
+    config->authVersion = AUTH_VERSION_APIKEY;
 }

--- a/src/log_producer_config.c
+++ b/src/log_producer_config.c
@@ -47,6 +47,7 @@ log_producer_config * create_log_producer_config()
     _set_default_producer_config(pConfig);
     pConfig->authVersion = AUTH_VERSION_1;
     pConfig->region = NULL;
+    pConfig->securityTokenLock = CreateCriticalSection();
     return pConfig;
 }
 
@@ -560,10 +561,40 @@ void log_producer_config_set_credentials_userdata(log_producer_config* config, v
 
 void log_producer_config_set_api_key(log_producer_config * config, const char * api_key)
 {
+    if (config == NULL || api_key == NULL || api_key[0] == '\0')
+    {
+        return;
+    }
+    CS_ENTER(config->securityTokenLock);
+    _copy_config_string(api_key, &config->apiKey);
+    config->authVersion = AUTH_VERSION_APIKEY;
+    CS_LEAVE(config->securityTokenLock);
+}
+
+void log_producer_config_reset_api_key(log_producer_config * config, const char * api_key)
+{
+    if (config == NULL || api_key == NULL || api_key[0] == '\0')
+    {
+        return;
+    }
+    CS_ENTER(config->securityTokenLock);
+    if (config->authVersion != AUTH_VERSION_APIKEY)
+    {
+        CS_LEAVE(config->securityTokenLock);
+        aos_error_log("reset api-key requires AUTH_VERSION_APIKEY mode");
+        return;
+    }
+    _copy_config_string(api_key, &config->apiKey);
+    CS_LEAVE(config->securityTokenLock);
+}
+
+void log_producer_config_get_api_key(log_producer_config * config, char ** api_key)
+{
     if (config == NULL || api_key == NULL)
     {
         return;
     }
-    _copy_config_string(api_key, &config->apiKey);
-    config->authVersion = AUTH_VERSION_APIKEY;
+    CS_ENTER(config->securityTokenLock);
+    _copy_config_string(config->apiKey, api_key);
+    CS_LEAVE(config->securityTokenLock);
 }

--- a/src/log_producer_config.h
+++ b/src/log_producer_config.h
@@ -74,6 +74,9 @@ typedef struct _log_producer_config
     on_get_credentials_function credentials_callback;
     void * credentials_userdata;
 
+    // API-Key authentication (mutually exclusive with accessKeyId/accessKey)
+    char * apiKey;
+
 }log_producer_config;
 
 
@@ -339,6 +342,16 @@ LOG_EXPORT void log_producer_config_set_credentials_callback(log_producer_config
  * @param userdata user-defined data passed to callback
  */
 LOG_EXPORT void log_producer_config_set_credentials_userdata(log_producer_config * config, void * userdata);
+
+/**
+ * set producer config api-key for API-Key authentication mode
+ * @note api-key mode is mutually exclusive with access-key mode and credentials callback
+ * @note api-key mode requires HTTPS, otherwise config validation will fail
+ * @note this will automatically set authVersion to AUTH_VERSION_APIKEY
+ * @param config
+ * @param api_key the API-Key string
+ */
+LOG_EXPORT void log_producer_config_set_api_key(log_producer_config * config, const char * api_key);
 
 
 LOG_CPP_END

--- a/src/log_producer_config.h
+++ b/src/log_producer_config.h
@@ -47,6 +47,7 @@ typedef struct _log_producer_config
     char * source;
     auth_version authVersion;
     char * region;
+    // Shared lock for AK/STS and API-Key credential snapshots.
     CRITICALSECTION securityTokenLock;
     log_producer_config_tag * tags;
     int32_t tagAllocSize;
@@ -348,10 +349,24 @@ LOG_EXPORT void log_producer_config_set_credentials_userdata(log_producer_config
  * @note api-key mode is mutually exclusive with access-key mode and credentials callback
  * @note api-key mode requires HTTPS, otherwise config validation will fail
  * @note this will automatically set authVersion to AUTH_VERSION_APIKEY
+ * @note call this before create_log_producer; use reset_api_key for runtime rotation
  * @param config
  * @param api_key the API-Key string
  */
 LOG_EXPORT void log_producer_config_set_api_key(log_producer_config * config, const char * api_key);
+
+/**
+ * reset API-Key while producer is running (thread safe)
+ * @note config must already be in AUTH_VERSION_APIKEY mode
+ * @param config
+ * @param api_key the new non-empty API-Key string
+ */
+LOG_EXPORT void log_producer_config_reset_api_key(log_producer_config * config, const char * api_key);
+
+/**
+ * inner api: copy the current API-Key under the shared credential lock
+ */
+LOG_EXPORT void log_producer_config_get_api_key(log_producer_config * config, char ** api_key);
 
 
 LOG_CPP_END

--- a/src/log_producer_sender.c
+++ b/src/log_producer_sender.c
@@ -324,8 +324,8 @@ void * log_producer_send_fun(void * param)
 
         if (config->authVersion == AUTH_VERSION_APIKEY)
         {
-            // API-Key mode: pass apiKey via accesskeyId parameter
-            accessKeyId = sdsnew(config->apiKey);
+            // API-Key mode: copy a request-scoped snapshot under the shared credential lock.
+            log_producer_config_get_api_key(config, &accessKeyId);
         }
         else
         {
@@ -565,5 +565,4 @@ log_producer_send_param * create_log_producer_destroy_param(log_producer_config 
     param->builder_time = 0;
     return param;
 }
-
 

--- a/src/log_producer_sender.c
+++ b/src/log_producer_sender.c
@@ -321,7 +321,16 @@ void * log_producer_send_fun(void * param)
         sds accessKeyId = NULL;
         sds accessKey = NULL;
         sds stsToken = NULL;
-        _get_credentials_for_sign(producer_manager, &accessKeyId, &accessKey, &stsToken);
+
+        if (config->authVersion == AUTH_VERSION_APIKEY)
+        {
+            // API-Key mode: pass apiKey via accesskeyId parameter
+            accessKeyId = sdsnew(config->apiKey);
+        }
+        else
+        {
+            _get_credentials_for_sign(producer_manager, &accessKeyId, &accessKey, &stsToken);
+        }
 
         post_log_result * rst = post_logs_from_lz4buf(config->endpoint, accessKeyId,
                                                       accessKey, stsToken,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+find_package(Threads)
+if(CMAKE_USE_PTHREADS_INIT)
+    include_directories(${CMAKE_SOURCE_DIR}/src)
+    add_executable(api_key_rotation_test api_key_rotation_test.c)
+    target_link_libraries(api_key_rotation_test log_c_sdk_static ${CMAKE_THREAD_LIBS_INIT})
+    add_test(NAME api_key_rotation_test COMMAND api_key_rotation_test)
+endif()

--- a/tests/api_key_rotation_test.c
+++ b/tests/api_key_rotation_test.c
@@ -1,0 +1,93 @@
+#include "log_producer_config.h"
+#include "sds.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <string.h>
+
+#define ROTATION_COUNT 10000
+#define READER_COUNT 4
+
+static const char * API_KEY_INITIAL = "api-key-initial-00000000000000000000";
+static const char * API_KEY_A = "api-key-a-aaaaaaaaaaaaaaaaaaaaaaaa";
+static const char * API_KEY_B = "api-key-b-bbbbbbbbbbbbbbbbbbbbbbbb";
+
+typedef struct _rotation_context
+{
+    log_producer_config * config;
+} rotation_context;
+
+static int is_expected_key(const char * api_key)
+{
+    return strcmp(api_key, API_KEY_INITIAL) == 0
+        || strcmp(api_key, API_KEY_A) == 0
+        || strcmp(api_key, API_KEY_B) == 0;
+}
+
+static void * rotate_api_key(void * userdata)
+{
+    rotation_context * context = (rotation_context *)userdata;
+    int i = 0;
+    for (; i < ROTATION_COUNT; ++i)
+    {
+        log_producer_config_reset_api_key(context->config, i % 2 == 0 ? API_KEY_A : API_KEY_B);
+    }
+    return NULL;
+}
+
+static void * read_api_key(void * userdata)
+{
+    rotation_context * context = (rotation_context *)userdata;
+    int i = 0;
+    for (; i < ROTATION_COUNT; ++i)
+    {
+        sds api_key = NULL;
+        log_producer_config_get_api_key(context->config, &api_key);
+        if (api_key == NULL || !is_expected_key(api_key))
+        {
+            sdsfree(api_key);
+            return (void *)1;
+        }
+        sdsfree(api_key);
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    log_producer_config * config = create_log_producer_config();
+    rotation_context context;
+    sds in_flight_snapshot = NULL;
+    sds rotated_snapshot = NULL;
+    pthread_t writer;
+    pthread_t readers[READER_COUNT];
+    int i = 0;
+
+    assert(config != NULL);
+    log_producer_config_set_api_key(config, API_KEY_INITIAL);
+    log_producer_config_get_api_key(config, &in_flight_snapshot);
+    log_producer_config_reset_api_key(config, API_KEY_A);
+    log_producer_config_get_api_key(config, &rotated_snapshot);
+    assert(strcmp(in_flight_snapshot, API_KEY_INITIAL) == 0);
+    assert(strcmp(rotated_snapshot, API_KEY_A) == 0);
+    sdsfree(in_flight_snapshot);
+    sdsfree(rotated_snapshot);
+    context.config = config;
+
+    assert(pthread_create(&writer, NULL, rotate_api_key, &context) == 0);
+    for (; i < READER_COUNT; ++i)
+    {
+        assert(pthread_create(&readers[i], NULL, read_api_key, &context) == 0);
+    }
+
+    assert(pthread_join(writer, NULL) == 0);
+    for (i = 0; i < READER_COUNT; ++i)
+    {
+        void * result = NULL;
+        assert(pthread_join(readers[i], &result) == 0);
+        assert(result == NULL);
+    }
+
+    destroy_log_producer_config(config);
+    return 0;
+}

--- a/tests/api_key_rotation_test.c
+++ b/tests/api_key_rotation_test.c
@@ -55,16 +55,35 @@ static void * read_api_key(void * userdata)
 
 int main(void)
 {
+    log_producer_config * static_ak_config = create_log_producer_config();
     log_producer_config * config = create_log_producer_config();
     rotation_context context;
+    sds access_key_id = NULL;
+    sds access_key_secret = NULL;
+    sds security_token = NULL;
     sds in_flight_snapshot = NULL;
     sds rotated_snapshot = NULL;
     pthread_t writer;
     pthread_t readers[READER_COUNT];
     int i = 0;
 
+    assert(static_ak_config != NULL);
+    assert(static_ak_config->securityTokenLock == NULL);
+    log_producer_config_set_access_id(static_ak_config, "test-access-key-id");
+    log_producer_config_set_access_key(static_ak_config, "test-access-key-secret");
+    log_producer_config_get_security(static_ak_config, &access_key_id, &access_key_secret, &security_token);
+    assert(static_ak_config->securityTokenLock == NULL);
+    assert(strcmp(access_key_id, "test-access-key-id") == 0);
+    assert(strcmp(access_key_secret, "test-access-key-secret") == 0);
+    sdsfree(access_key_id);
+    sdsfree(access_key_secret);
+    sdsfree(security_token);
+    destroy_log_producer_config(static_ak_config);
+
     assert(config != NULL);
+    assert(config->securityTokenLock == NULL);
     log_producer_config_set_api_key(config, API_KEY_INITIAL);
+    assert(config->securityTokenLock != NULL);
     log_producer_config_get_api_key(config, &in_flight_snapshot);
     log_producer_config_reset_api_key(config, API_KEY_A);
     log_producer_config_get_api_key(config, &rotated_snapshot);


### PR DESCRIPTION
## Summary

Add a new API-Key authentication mode that uses `Bearer <api-key>` as the Authorization header, as a simpler alternative to AccessKey (HMAC signature) authentication.

## Changes

- Add `AUTH_VERSION_APIKEY` enum value
- Add `log_producer_config_set_api_key()` public API
- API-Key mode is mutually exclusive with AccessKey mode and credentials callback
- HTTPS is required for API-Key mode
- Add Bearer token Authorization header construction in `log_api.c`
- Skip credential fetching in sender for API-Key mode
- Add sample code (`log_apikey_sample.c`) and documentation (`ApiKeyAuth.md`)
- Update CHANGELOG.md

## Files Changed

- `src/log_define.h` - New enum value
- `src/log_producer_config.h` - New field + API declaration
- `src/log_producer_config.c` - Implementation + validation
- `src/log_producer_sender.c` - Sender adaptation
- `src/log_api.c` - Bearer token header branch
- `sample/log_apikey_sample.c` - Usage example
- `sample/ApiKeyAuth.md` - Documentation
- `sample/CMakeLists.txt` - Build target
- `CHANGELOG.md` - Version entry