### PR TITLE
feat(live): add API-Key Bearer token authentication mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,3 +79,9 @@ INSTALL(FILES
   DESTINATION include/log_c_sdk)
 
 add_subdirectory(sample)
+
+option(BUILD_TESTING "Build SDK tests" OFF)
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/docs/cn/ApiKeyAuth.md
+++ b/docs/cn/ApiKeyAuth.md
@@ -1,0 +1,27 @@
+# API-Key 鉴权使用说明
+
+API-Key 模式使用 Authorization Header 中的 `Bearer <api-key>` 进行鉴权，不再使用 AccessKey 签名。
+
+## 约束
+
+- 必须使用 HTTPS。
+- API-Key 模式与 AccessKey 模式互斥。
+- producer 创建前使用 `log_producer_config_set_api_key()` 设置初始 API-Key。
+- producer 运行期间使用 `log_producer_config_reset_api_key()` 线程安全地轮转 API-Key。
+
+## 使用方式
+
+```c
+log_producer_config * config = create_log_producer_config();
+log_producer_config_set_endpoint(config, "https://cn-hangzhou.log.aliyuncs.com");
+log_producer_config_set_project(config, "my-project");
+log_producer_config_set_logstore(config, "my-logstore");
+log_producer_config_set_api_key(config, "your-api-key");
+
+log_producer * producer = create_log_producer(config, NULL, NULL);
+
+// 正在发送的请求继续使用旧快照，后续请求使用新的 API-Key。
+log_producer_config_reset_api_key(config, "your-new-api-key");
+
+destroy_log_producer(producer);
+```

--- a/docs/en/ApiKeyAuth.md
+++ b/docs/en/ApiKeyAuth.md
@@ -1,0 +1,27 @@
+# API-Key Authentication Guide
+
+API-Key mode sends `Bearer <api-key>` in the Authorization header instead of using AccessKey signing.
+
+## Constraints
+
+- HTTPS is required.
+- API-Key mode is mutually exclusive with AccessKey mode.
+- Use `log_producer_config_set_api_key()` before creating the producer.
+- Use `log_producer_config_reset_api_key()` for thread-safe runtime rotation.
+
+## Usage
+
+```c
+log_producer_config * config = create_log_producer_config();
+log_producer_config_set_endpoint(config, "https://cn-hangzhou.log.aliyuncs.com");
+log_producer_config_set_project(config, "my-project");
+log_producer_config_set_logstore(config, "my-logstore");
+log_producer_config_set_api_key(config, "your-api-key");
+
+log_producer * producer = create_log_producer(config, NULL, NULL);
+
+// In-flight requests keep their old snapshot; subsequent requests use the new key.
+log_producer_config_reset_api_key(config, "your-new-api-key");
+
+destroy_log_producer(producer);
+```

--- a/src/log_api.c
+++ b/src/log_api.c
@@ -265,6 +265,52 @@ post_log_result * post_logs_from_lz4buf(const char *endpoint, const char * acces
 
         struct curl_slist* headers = NULL;
 
+        int auth_version = option != NULL ? option->auth_version : AUTH_VERSION_1;
+
+        if (auth_version == AUTH_VERSION_APIKEY)
+        {
+            // API-Key mode: basic headers + Bearer token, no signature needed
+            headers=curl_slist_append(headers, "Content-Type:application/x-protobuf");
+            headers=curl_slist_append(headers, "x-log-apiversion:0.6.0");
+            if (lz4Flag)
+            {
+                headers = curl_slist_append(headers, "x-log-compresstype:lz4");
+            }
+
+            sds headerHost = sdsnewEmpty(128);
+            headerHost = sdscatprintf(headerHost, "Host:%s.%s", project, endpoint);
+            headers=curl_slist_append(headers, headerHost);
+
+            sds headerLen = sdsnewEmpty(64);
+            headerLen = sdscatprintf(headerLen, "Content-Length:%d", (int)buffer->length);
+            headers=curl_slist_append(headers, headerLen);
+
+            sds headerRawLen = sdsnewEmpty(64);
+            headerRawLen = sdscatprintf(headerRawLen, "x-log-bodyrawsize:%d", (int)buffer->raw_length);
+            headers=curl_slist_append(headers, headerRawLen);
+
+            sds headerTime = sdsnew("Date:");
+            headerTime = sdscat(headerTime, nowTime);
+            headers=curl_slist_append(headers, headerTime);
+
+            sds headerMD5 = sdsnew("Content-MD5:");
+            headerMD5 = sdscat(headerMD5, md5Buf);
+            headers=curl_slist_append(headers, headerMD5);
+
+            // Authorization: Bearer <api-key>
+            sds headerAuth = sdsnewEmpty(256);
+            headerAuth = sdscatprintf(headerAuth, "Authorization:Bearer %s", accesskeyId);
+            headers=curl_slist_append(headers, headerAuth);
+
+            sdsfree(headerHost);
+            sdsfree(headerLen);
+            sdsfree(headerRawLen);
+            sdsfree(headerTime);
+            sdsfree(headerMD5);
+            sdsfree(headerAuth);
+        }
+        else
+        {
         headers=curl_slist_append(headers, "Content-Type:application/x-protobuf");
         headers=curl_slist_append(headers, "x-log-apiversion:0.6.0");
         if (lz4Flag)
@@ -343,6 +389,15 @@ post_log_result * post_logs_from_lz4buf(const char *endpoint, const char * acces
         headerSig = sdscatprintf(headerSig, "Authorization:LOG %s:%s", accesskeyId, sha1Buf);
         //puts(headerSig);
         headers=curl_slist_append(headers, headerSig);
+        sdsfree(headerTime);
+        sdsfree(headerMD5);
+        sdsfree(headerLen);
+        sdsfree(headerRawLen);
+        sdsfree(headerHost);
+        sdsfree(sigContent);
+        sdsfree(headerSig);
+        } // end of AK mode auth block
+
 
 
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
@@ -433,13 +488,6 @@ post_log_result * post_logs_from_lz4buf(const char *endpoint, const char * acces
 
         curl_slist_free_all(headers); /* free the list again */
         sdsfree(url);
-        sdsfree(headerTime);
-        sdsfree(headerMD5);
-        sdsfree(headerLen);
-        sdsfree(headerRawLen);
-        sdsfree(headerHost);
-        sdsfree(sigContent);
-        sdsfree(headerSig);
         /* always cleanup */
         curl_easy_cleanup(curl);
     }

--- a/src/log_api.h
+++ b/src/log_api.h
@@ -18,6 +18,7 @@ struct _log_post_option
   int compress_type; // 0 no compress, 1 lz4
   int ntp_time_offset; //time offset between local time and server time
   int using_https; // 0 http, 1 https
+  auth_version auth_version; // AUTH_VERSION_1 or AUTH_VERSION_APIKEY
 };
 typedef struct _log_post_option log_post_option;
 

--- a/src/log_define.h
+++ b/src/log_define.h
@@ -28,4 +28,17 @@ struct _post_log_result
 typedef struct _post_log_result post_log_result;
 
 
+#ifdef WIN32
+typedef int auth_version;
+#define AUTH_VERSION_1       1
+#define AUTH_VERSION_APIKEY  2
+#else
+enum _auth_version
+{
+    AUTH_VERSION_1 = 1,
+    AUTH_VERSION_APIKEY   // API-Key Bearer token auth
+};
+typedef enum _auth_version auth_version;
+#endif
+
 #endif

--- a/src/log_producer_config.c
+++ b/src/log_producer_config.c
@@ -22,6 +22,7 @@ static void _set_default_producer_config(log_producer_config * pConfig)
     pConfig->compressType = 1;
     pConfig->ntpTimeOffset = 0;
     pConfig->using_https = 0;
+    pConfig->authVersion = AUTH_VERSION_1;
 }
 
 
@@ -100,6 +101,10 @@ void destroy_log_producer_config(log_producer_config * pConfig)
             sdsfree(pConfig->tags[i].value);
         }
         free(pConfig->tags);
+    }
+    if (pConfig->apiKey != NULL)
+    {
+        sdsfree(pConfig->apiKey);
     }
     free(pConfig);
 }
@@ -367,10 +372,38 @@ int log_producer_config_is_valid(log_producer_config * config)
         aos_error_log("invalid producer config destination params");
         return 0;
     }
-    if (config->accessKey == NULL || config->accessKeyId == NULL)
+    // API-Key mode validation
+    if (config->authVersion == AUTH_VERSION_APIKEY)
     {
-        aos_error_log("invalid producer config authority params");
-        return 0;
+        if (config->accessKeyId != NULL || config->accessKey != NULL)
+        {
+            aos_error_log("api-key mode is mutually exclusive with access-key mode");
+            return 0;
+        }
+        if (config->using_https != 1)
+        {
+            aos_error_log("api-key mode requires HTTPS");
+            return 0;
+        }
+        if (config->apiKey == NULL || strlen(config->apiKey) == 0)
+        {
+            aos_error_log("api-key mode requires a non-empty api-key");
+            return 0;
+        }
+    }
+    else
+    {
+        // AK mode should not have apiKey set
+        if (config->apiKey != NULL)
+        {
+            aos_error_log("apiKey is set but authVersion is not AUTH_VERSION_APIKEY, conflict");
+            return 0;
+        }
+        if (config->accessKey == NULL || config->accessKeyId == NULL)
+        {
+            aos_error_log("invalid producer config authority params");
+            return 0;
+        }
     }
     if (config->packageTimeoutInMS < 0 || config->maxBufferBytes < 0 || config->logCountPerPackage < 0 || config->logBytesPerPackage < 0)
     {
@@ -387,4 +420,14 @@ void log_producer_config_set_using_http(log_producer_config * config, int32_t us
         return;
     }
     config->using_https = using_https;
+}
+
+void log_producer_config_set_api_key(log_producer_config * config, const char * api_key)
+{
+    if (config == NULL || api_key == NULL)
+    {
+        return;
+    }
+    _copy_config_string(api_key, &config->apiKey);
+    config->authVersion = AUTH_VERSION_APIKEY;
 }

--- a/src/log_producer_config.c
+++ b/src/log_producer_config.c
@@ -46,6 +46,7 @@ log_producer_config * create_log_producer_config()
     log_producer_config* pConfig = (log_producer_config*)malloc(sizeof(log_producer_config));
     memset(pConfig, 0, sizeof(log_producer_config));
     _set_default_producer_config(pConfig);
+    pConfig->securityTokenLock = CreateCriticalSection();
     return pConfig;
 }
 
@@ -424,10 +425,40 @@ void log_producer_config_set_using_http(log_producer_config * config, int32_t us
 
 void log_producer_config_set_api_key(log_producer_config * config, const char * api_key)
 {
+    if (config == NULL || api_key == NULL || api_key[0] == '\0')
+    {
+        return;
+    }
+    CS_ENTER(config->securityTokenLock);
+    _copy_config_string(api_key, &config->apiKey);
+    config->authVersion = AUTH_VERSION_APIKEY;
+    CS_LEAVE(config->securityTokenLock);
+}
+
+void log_producer_config_reset_api_key(log_producer_config * config, const char * api_key)
+{
+    if (config == NULL || api_key == NULL || api_key[0] == '\0')
+    {
+        return;
+    }
+    CS_ENTER(config->securityTokenLock);
+    if (config->authVersion != AUTH_VERSION_APIKEY)
+    {
+        CS_LEAVE(config->securityTokenLock);
+        aos_error_log("reset api-key requires AUTH_VERSION_APIKEY mode");
+        return;
+    }
+    _copy_config_string(api_key, &config->apiKey);
+    CS_LEAVE(config->securityTokenLock);
+}
+
+void log_producer_config_get_api_key(log_producer_config * config, char ** api_key)
+{
     if (config == NULL || api_key == NULL)
     {
         return;
     }
-    _copy_config_string(api_key, &config->apiKey);
-    config->authVersion = AUTH_VERSION_APIKEY;
+    CS_ENTER(config->securityTokenLock);
+    _copy_config_string(config->apiKey, api_key);
+    CS_LEAVE(config->securityTokenLock);
 }

--- a/src/log_producer_config.c
+++ b/src/log_producer_config.c
@@ -46,7 +46,6 @@ log_producer_config * create_log_producer_config()
     log_producer_config* pConfig = (log_producer_config*)malloc(sizeof(log_producer_config));
     memset(pConfig, 0, sizeof(log_producer_config));
     _set_default_producer_config(pConfig);
-    pConfig->securityTokenLock = CreateCriticalSection();
     return pConfig;
 }
 
@@ -429,6 +428,10 @@ void log_producer_config_set_api_key(log_producer_config * config, const char * 
     {
         return;
     }
+    if (config->securityTokenLock == NULL)
+    {
+        config->securityTokenLock = CreateCriticalSection();
+    }
     CS_ENTER(config->securityTokenLock);
     _copy_config_string(api_key, &config->apiKey);
     config->authVersion = AUTH_VERSION_APIKEY;
@@ -439,6 +442,11 @@ void log_producer_config_reset_api_key(log_producer_config * config, const char 
 {
     if (config == NULL || api_key == NULL || api_key[0] == '\0')
     {
+        return;
+    }
+    if (config->securityTokenLock == NULL)
+    {
+        aos_error_log("reset api-key requires initialized API-Key mode");
         return;
     }
     CS_ENTER(config->securityTokenLock);
@@ -456,6 +464,11 @@ void log_producer_config_get_api_key(log_producer_config * config, char ** api_k
 {
     if (config == NULL || api_key == NULL)
     {
+        return;
+    }
+    if (config->securityTokenLock == NULL)
+    {
+        _copy_config_string(config->apiKey, api_key);
         return;
     }
     CS_ENTER(config->securityTokenLock);

--- a/src/log_producer_config.h
+++ b/src/log_producer_config.h
@@ -52,6 +52,10 @@ typedef struct _log_producer_config
     int32_t compressType; // 0 no compress, 1 lz4
     int32_t ntpTimeOffset;
     int32_t using_https; // 0 http, 1 https
+    auth_version authVersion;
+
+    // API-Key authentication (mutually exclusive with accessKeyId/accessKey)
+    char * apiKey;
 }log_producer_config;
 
 
@@ -258,6 +262,16 @@ LOG_EXPORT int log_producer_config_is_valid(log_producer_config * config);
  * @param using_https 0 http, 1 https
  */
 LOG_EXPORT void log_producer_config_set_using_http(log_producer_config * config, int32_t using_https);
+
+/**
+ * set producer config api-key for API-Key authentication mode
+ * @note api-key mode is mutually exclusive with access-key mode
+ * @note api-key mode requires HTTPS, otherwise config validation will fail
+ * @note this will automatically set authVersion to AUTH_VERSION_APIKEY
+ * @param config
+ * @param api_key the API-Key string
+ */
+LOG_EXPORT void log_producer_config_set_api_key(log_producer_config * config, const char * api_key);
 
 LOG_CPP_END
 

--- a/src/log_producer_config.h
+++ b/src/log_producer_config.h
@@ -30,6 +30,7 @@ typedef struct _log_producer_config
     char * securityToken;
     char * topic;
     char * source;
+    // Shared lock for AK/STS and API-Key credential snapshots.
     CRITICALSECTION securityTokenLock;
     log_producer_config_tag * tags;
     int32_t tagAllocSize;
@@ -268,10 +269,22 @@ LOG_EXPORT void log_producer_config_set_using_http(log_producer_config * config,
  * @note api-key mode is mutually exclusive with access-key mode
  * @note api-key mode requires HTTPS, otherwise config validation will fail
  * @note this will automatically set authVersion to AUTH_VERSION_APIKEY
+ * @note call this before create_log_producer; use reset_api_key for runtime rotation
  * @param config
  * @param api_key the API-Key string
  */
 LOG_EXPORT void log_producer_config_set_api_key(log_producer_config * config, const char * api_key);
+
+/**
+ * reset API-Key while producer is running (thread safe)
+ * @note config must already be in AUTH_VERSION_APIKEY mode
+ */
+LOG_EXPORT void log_producer_config_reset_api_key(log_producer_config * config, const char * api_key);
+
+/**
+ * inner api: copy the current API-Key under the shared credential lock
+ */
+LOG_EXPORT void log_producer_config_get_api_key(log_producer_config * config, char ** api_key);
 
 LOG_CPP_END
 

--- a/src/log_producer_sender.c
+++ b/src/log_producer_sender.c
@@ -159,6 +159,7 @@ void * log_producer_send_fun(void * param)
         option.compress_type = config->compressType;
         option.ntp_time_offset = config->ntpTimeOffset;
         option.using_https = config->using_https;
+        option.auth_version = config->authVersion;
         sds accessKeyId = NULL;
         sds accessKey = NULL;
         sds stsToken = NULL;

--- a/src/log_producer_sender.c
+++ b/src/log_producer_sender.c
@@ -163,7 +163,14 @@ void * log_producer_send_fun(void * param)
         sds accessKeyId = NULL;
         sds accessKey = NULL;
         sds stsToken = NULL;
-        log_producer_config_get_security(config, &accessKeyId, &accessKey, &stsToken);
+        if (config->authVersion == AUTH_VERSION_APIKEY)
+        {
+            log_producer_config_get_api_key(config, &accessKeyId);
+        }
+        else
+        {
+            log_producer_config_get_security(config, &accessKeyId, &accessKey, &stsToken);
+        }
         post_log_result * rst = post_logs_from_lz4buf(config->endpoint, accessKeyId, accessKey, stsToken, config->project, config->logstore, send_buf, &option);
         sdsfree(accessKeyId);
         sdsfree(accessKey);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+find_package(Threads)
+if(CMAKE_USE_PTHREADS_INIT)
+    include_directories(${CMAKE_SOURCE_DIR}/src)
+    add_executable(api_key_rotation_test api_key_rotation_test.c)
+    target_link_libraries(api_key_rotation_test log_c_sdk_static ${CMAKE_THREAD_LIBS_INIT})
+    add_test(NAME api_key_rotation_test COMMAND api_key_rotation_test)
+endif()

--- a/tests/api_key_rotation_test.c
+++ b/tests/api_key_rotation_test.c
@@ -1,0 +1,93 @@
+#include "log_producer_config.h"
+#include "sds.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <string.h>
+
+#define ROTATION_COUNT 10000
+#define READER_COUNT 4
+
+static const char * API_KEY_INITIAL = "api-key-initial-00000000000000000000";
+static const char * API_KEY_A = "api-key-a-aaaaaaaaaaaaaaaaaaaaaaaa";
+static const char * API_KEY_B = "api-key-b-bbbbbbbbbbbbbbbbbbbbbbbb";
+
+typedef struct _rotation_context
+{
+    log_producer_config * config;
+} rotation_context;
+
+static int is_expected_key(const char * api_key)
+{
+    return strcmp(api_key, API_KEY_INITIAL) == 0
+        || strcmp(api_key, API_KEY_A) == 0
+        || strcmp(api_key, API_KEY_B) == 0;
+}
+
+static void * rotate_api_key(void * userdata)
+{
+    rotation_context * context = (rotation_context *)userdata;
+    int i = 0;
+    for (; i < ROTATION_COUNT; ++i)
+    {
+        log_producer_config_reset_api_key(context->config, i % 2 == 0 ? API_KEY_A : API_KEY_B);
+    }
+    return NULL;
+}
+
+static void * read_api_key(void * userdata)
+{
+    rotation_context * context = (rotation_context *)userdata;
+    int i = 0;
+    for (; i < ROTATION_COUNT; ++i)
+    {
+        sds api_key = NULL;
+        log_producer_config_get_api_key(context->config, &api_key);
+        if (api_key == NULL || !is_expected_key(api_key))
+        {
+            sdsfree(api_key);
+            return (void *)1;
+        }
+        sdsfree(api_key);
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    log_producer_config * config = create_log_producer_config();
+    rotation_context context;
+    sds in_flight_snapshot = NULL;
+    sds rotated_snapshot = NULL;
+    pthread_t writer;
+    pthread_t readers[READER_COUNT];
+    int i = 0;
+
+    assert(config != NULL);
+    log_producer_config_set_api_key(config, API_KEY_INITIAL);
+    log_producer_config_get_api_key(config, &in_flight_snapshot);
+    log_producer_config_reset_api_key(config, API_KEY_A);
+    log_producer_config_get_api_key(config, &rotated_snapshot);
+    assert(strcmp(in_flight_snapshot, API_KEY_INITIAL) == 0);
+    assert(strcmp(rotated_snapshot, API_KEY_A) == 0);
+    sdsfree(in_flight_snapshot);
+    sdsfree(rotated_snapshot);
+    context.config = config;
+
+    assert(pthread_create(&writer, NULL, rotate_api_key, &context) == 0);
+    for (; i < READER_COUNT; ++i)
+    {
+        assert(pthread_create(&readers[i], NULL, read_api_key, &context) == 0);
+    }
+
+    assert(pthread_join(writer, NULL) == 0);
+    for (i = 0; i < READER_COUNT; ++i)
+    {
+        void * result = NULL;
+        assert(pthread_join(readers[i], &result) == 0);
+        assert(result == NULL);
+    }
+
+    destroy_log_producer_config(config);
+    return 0;
+}

--- a/tests/api_key_rotation_test.c
+++ b/tests/api_key_rotation_test.c
@@ -55,16 +55,35 @@ static void * read_api_key(void * userdata)
 
 int main(void)
 {
+    log_producer_config * static_ak_config = create_log_producer_config();
     log_producer_config * config = create_log_producer_config();
     rotation_context context;
+    sds access_key_id = NULL;
+    sds access_key_secret = NULL;
+    sds security_token = NULL;
     sds in_flight_snapshot = NULL;
     sds rotated_snapshot = NULL;
     pthread_t writer;
     pthread_t readers[READER_COUNT];
     int i = 0;
 
+    assert(static_ak_config != NULL);
+    assert(static_ak_config->securityTokenLock == NULL);
+    log_producer_config_set_access_id(static_ak_config, "test-access-key-id");
+    log_producer_config_set_access_key(static_ak_config, "test-access-key-secret");
+    log_producer_config_get_security(static_ak_config, &access_key_id, &access_key_secret, &security_token);
+    assert(static_ak_config->securityTokenLock == NULL);
+    assert(strcmp(access_key_id, "test-access-key-id") == 0);
+    assert(strcmp(access_key_secret, "test-access-key-secret") == 0);
+    sdsfree(access_key_id);
+    sdsfree(access_key_secret);
+    sdsfree(security_token);
+    destroy_log_producer_config(static_ak_config);
+
     assert(config != NULL);
+    assert(config->securityTokenLock == NULL);
     log_producer_config_set_api_key(config, API_KEY_INITIAL);
+    assert(config->securityTokenLock != NULL);
     log_producer_config_get_api_key(config, &in_flight_snapshot);
     log_producer_config_reset_api_key(config, API_KEY_A);
     log_producer_config_get_api_key(config, &rotated_snapshot);


### PR DESCRIPTION
## Summary

Add API-Key Bearer token authentication as an alternative to AccessKey (HMAC-SHA1) mode for the **live** branch.

## Changes

### Core
- `src/log_define.h`: Add `auth_version` enum (`AUTH_VERSION_1`, `AUTH_VERSION_APIKEY`)
- `src/log_producer_config.h/c`: Add `using_https`, `authVersion`, `apiKey` fields; add setter functions and validation logic
- `src/log_api.h/c`: Add `using_https` and `auth_version` to `log_post_option`; support HTTPS URL and Bearer token auth branch
- `src/log_producer_sender.c`: Pass `using_https`/`auth_version` from config; skip AK credential retrieval in API-Key mode

### Documentation
- `docs/cn/ApiKeyAuth.md`: Chinese API-Key authentication guide
- `docs/en/ApiKeyAuth.md`: English API-Key authentication guide

## Key Design
- API-Key mode sends `Authorization: Bearer <api-key>` header (no signature computation)
- Mutually exclusive with AccessKey mode (validated at config level)
- HTTPS is mandatory for API-Key mode (validated at config level)
- Compilation verified on macOS