### PR TITLE
feat(persistent): add API-Key Bearer token authentication mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,3 +63,9 @@ INSTALL(FILES
   DESTINATION include/log_c_sdk)
 
 add_subdirectory(sample)
+
+option(BUILD_TESTING "Build SDK tests" OFF)
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/docs/cn/ApiKeyAuth.md
+++ b/docs/cn/ApiKeyAuth.md
@@ -1,0 +1,55 @@
+# API-Key 鉴权使用说明
+
+API-Key 鉴权模式允许用户使用 API-Key 进行身份认证，无需 AccessKey ID / AccessKey Secret，无需签名计算。SDK 会在 Authorization Header 中携带 `Bearer <api-key>` 进行认证。
+
+## 约束
+
+- **HTTPS 强制**：API-Key 模式**必须**使用 HTTPS，否则 producer 创建会失败
+- **与 AK 模式互斥**：不能同时设置 API-Key 和 AccessKey ID / AccessKey Secret，否则 producer 创建会失败
+- **不支持轮转**：API-Key 模式不支持动态凭证轮转
+- **持久化兼容**：API-Key 模式与持久化存储功能完全兼容，凭证不会持久化到磁盘
+
+## 使用方式
+
+```c
+#include "log_api.h"
+#include "log_producer_config.h"
+#include "log_producer_client.h"
+
+// 1. 创建 producer 配置
+log_producer_config * config = create_log_producer_config();
+
+// endpoint 必须以 "https://" 开头
+log_producer_config_set_endpoint(config, "https://cn-hangzhou.log.aliyuncs.com");
+log_producer_config_set_project(config, "my-project");
+log_producer_config_set_logstore(config, "my-logstore");
+
+// 2. 设置 API-Key（会自动设置 authVersion = AUTH_VERSION_APIKEY）
+//    注意：不要再调用 log_producer_config_set_access_id / set_access_key
+log_producer_config_set_api_key(config, "your-api-key");
+
+// 3. 可选：启用持久化存储
+log_producer_config_set_persistent(config, 1);
+log_producer_config_set_persistent_file_path(config, "/app/data/log.dat");
+log_producer_config_set_persistent_max_file_count(config, 10);
+log_producer_config_set_persistent_max_file_size(config, 1024 * 1024);
+log_producer_config_set_persistent_max_log_count(config, 65536);
+
+// 4. 创建 producer 并使用
+log_producer * producer = create_log_producer(config, NULL);
+log_producer_client * client = get_log_producer_client(producer, NULL);
+
+// 发送日志
+log_producer_client_add_log(client, 4, "key1", "value1", "key2", "value2");
+
+// 5. 清理
+destroy_log_producer(producer);
+```
+
+## 常见错误
+
+| 错误信息 | 原因 | 解决方法 |
+|---------|------|---------|
+| `api-key mode requires HTTPS` | 未使用 HTTPS | endpoint 以 `https://` 开头，或调用 `log_producer_config_set_using_http(config, 1)` |
+| `api-key mode is mutually exclusive with access-key mode` | 同时设置了 API-Key 和 AccessKey | 只使用其中一种鉴权方式 |
+| `api-key mode requires a non-empty api-key` | API-Key 为空 | 传入有效的 API-Key 字符串 |

--- a/docs/cn/ApiKeyAuth.md
+++ b/docs/cn/ApiKeyAuth.md
@@ -6,7 +6,7 @@ API-Key 鉴权模式允许用户使用 API-Key 进行身份认证，无需 Acces
 
 - **HTTPS 强制**：API-Key 模式**必须**使用 HTTPS，否则 producer 创建会失败
 - **与 AK 模式互斥**：不能同时设置 API-Key 和 AccessKey ID / AccessKey Secret，否则 producer 创建会失败
-- **不支持轮转**：API-Key 模式不支持动态凭证轮转
+- **线程安全轮转**：producer 启动后调用 `log_producer_config_reset_api_key()` 更新 API-Key
 - **持久化兼容**：API-Key 模式与持久化存储功能完全兼容，凭证不会持久化到磁盘
 
 ## 使用方式
@@ -41,6 +41,10 @@ log_producer_client * client = get_log_producer_client(producer, NULL);
 
 // 发送日志
 log_producer_client_add_log(client, 4, "key1", "value1", "key2", "value2");
+
+// producer 运行期间线程安全地轮转 API-Key。正在发送的请求继续使用旧快照，
+// 后续请求使用新的 API-Key。
+log_producer_config_reset_api_key(config, "your-new-api-key");
 
 // 5. 清理
 destroy_log_producer(producer);

--- a/docs/en/ApiKeyAuth.md
+++ b/docs/en/ApiKeyAuth.md
@@ -1,0 +1,55 @@
+# API-Key Authentication Guide
+
+The API-Key authentication mode allows users to authenticate using an API-Key without AccessKey ID / AccessKey Secret and without signature calculation. The SDK sends `Bearer <api-key>` in the Authorization header for authentication.
+
+## Constraints
+
+- **HTTPS Required**: API-Key mode **must** use HTTPS; otherwise producer creation will fail
+- **Mutually Exclusive with AK Mode**: Cannot set both API-Key and AccessKey ID / AccessKey Secret simultaneously; otherwise producer creation will fail
+- **No Rotation Support**: API-Key mode does not support dynamic credential rotation
+- **Persistent Compatible**: API-Key mode is fully compatible with persistent storage; credentials are never persisted to disk
+
+## Usage
+
+```c
+#include "log_api.h"
+#include "log_producer_config.h"
+#include "log_producer_client.h"
+
+// 1. Create producer config
+log_producer_config * config = create_log_producer_config();
+
+// Endpoint must start with "https://"
+log_producer_config_set_endpoint(config, "https://cn-hangzhou.log.aliyuncs.com");
+log_producer_config_set_project(config, "my-project");
+log_producer_config_set_logstore(config, "my-logstore");
+
+// 2. Set API-Key (automatically sets authVersion = AUTH_VERSION_APIKEY)
+//    Note: Do NOT call log_producer_config_set_access_id / set_access_key
+log_producer_config_set_api_key(config, "your-api-key");
+
+// 3. Optional: enable persistent storage
+log_producer_config_set_persistent(config, 1);
+log_producer_config_set_persistent_file_path(config, "/app/data/log.dat");
+log_producer_config_set_persistent_max_file_count(config, 10);
+log_producer_config_set_persistent_max_file_size(config, 1024 * 1024);
+log_producer_config_set_persistent_max_log_count(config, 65536);
+
+// 4. Create producer and use it
+log_producer * producer = create_log_producer(config, NULL);
+log_producer_client * client = get_log_producer_client(producer, NULL);
+
+// Send logs
+log_producer_client_add_log(client, 4, "key1", "value1", "key2", "value2");
+
+// 5. Cleanup
+destroy_log_producer(producer);
+```
+
+## Common Errors
+
+| Error Message | Cause | Solution |
+|--------------|-------|----------|
+| `api-key mode requires HTTPS` | HTTPS not used | Ensure the endpoint starts with `https://`, or call `log_producer_config_set_using_http(config, 1)` |
+| `api-key mode is mutually exclusive with access-key mode` | Both API-Key and AccessKey are set | Use only one authentication method |
+| `api-key mode requires a non-empty api-key` | API-Key is empty | Provide a valid API-Key string |

--- a/docs/en/ApiKeyAuth.md
+++ b/docs/en/ApiKeyAuth.md
@@ -6,7 +6,7 @@ The API-Key authentication mode allows users to authenticate using an API-Key wi
 
 - **HTTPS Required**: API-Key mode **must** use HTTPS; otherwise producer creation will fail
 - **Mutually Exclusive with AK Mode**: Cannot set both API-Key and AccessKey ID / AccessKey Secret simultaneously; otherwise producer creation will fail
-- **No Rotation Support**: API-Key mode does not support dynamic credential rotation
+- **Thread-safe Rotation**: Use `log_producer_config_reset_api_key()` to rotate the key after the producer starts
 - **Persistent Compatible**: API-Key mode is fully compatible with persistent storage; credentials are never persisted to disk
 
 ## Usage
@@ -41,6 +41,10 @@ log_producer_client * client = get_log_producer_client(producer, NULL);
 
 // Send logs
 log_producer_client_add_log(client, 4, "key1", "value1", "key2", "value2");
+
+// Rotate the API-Key while the producer is running. In-flight requests keep
+// using their request-scoped snapshot; subsequent requests use the new key.
+log_producer_config_reset_api_key(config, "your-new-api-key");
 
 // 5. Cleanup
 destroy_log_producer(producer);

--- a/src/log_api.c
+++ b/src/log_api.c
@@ -466,8 +466,8 @@ post_log_result * post_logs_from_lz4buf_with_config(log_producer_config *config,
 
     if (is_str_empty(accessKeyId) || is_str_empty(accessKeySecret))
     {
-        // Allow empty AK when using API-Key mode (checked via config->authVersion)
-        if (config == NULL || config->authVersion != AUTH_VERSION_APIKEY)
+        // Allow empty AK secret when using the request's API-Key mode snapshot.
+        if (option == NULL || option->auth_version != AUTH_VERSION_APIKEY)
         {
             result->statusCode = 405;
             result->requestID  =  sdsnewEmpty(64);
@@ -515,7 +515,7 @@ post_log_result * post_logs_from_lz4buf_with_config(log_producer_config *config,
 
         struct cur_slist* headers = NULL;
 
-        int auth_version = (config != NULL) ? config->authVersion : AUTH_VERSION_1;
+        int auth_version = option != NULL ? option->auth_version : AUTH_VERSION_1;
 
         if (auth_version == AUTH_VERSION_APIKEY)
         {
@@ -549,7 +549,7 @@ post_log_result * post_logs_from_lz4buf_with_config(log_producer_config *config,
 
             // Authorization: Bearer <api-key>
             sds headerAuth = sdsnewEmpty(256);
-            headerAuth = sdscatprintf(headerAuth, "Authorization:Bearer %s", config->apiKey);
+            headerAuth = sdscatprintf(headerAuth, "Authorization:Bearer %s", accessKeyId);
             headers=cur_slist_append(headers, headerAuth);
 
             sdsfree(headerHost);

--- a/src/log_api.c
+++ b/src/log_api.c
@@ -466,10 +466,14 @@ post_log_result * post_logs_from_lz4buf_with_config(log_producer_config *config,
 
     if (is_str_empty(accessKeyId) || is_str_empty(accessKeySecret))
     {
-        result->statusCode = 405;
-        result->requestID  =  sdsnewEmpty(64);
-        result->errorMessage = sdsnew("Invalid producer config authority params");
-        return result;
+        // Allow empty AK when using API-Key mode (checked via config->authVersion)
+        if (config == NULL || config->authVersion != AUTH_VERSION_APIKEY)
+        {
+            result->statusCode = 405;
+            result->requestID  =  sdsnewEmpty(64);
+            result->errorMessage = sdsnew("Invalid producer config authority params");
+            return result;
+        }
     }
 
     {
@@ -511,7 +515,52 @@ post_log_result * post_logs_from_lz4buf_with_config(log_producer_config *config,
 
         struct cur_slist* headers = NULL;
 
-        headers=cur_slist_append(headers, "Content-Type:application/x-protobuf");
+        int auth_version = (config != NULL) ? config->authVersion : AUTH_VERSION_1;
+
+        if (auth_version == AUTH_VERSION_APIKEY)
+        {
+            // API-Key mode: basic headers + Bearer token, no signature needed
+            headers=cur_slist_append(headers, "Content-Type:application/x-protobuf");
+            headers=cur_slist_append(headers, "x-log-apiversion:0.6.0");
+            if (lz4Flag)
+            {
+                headers = cur_slist_append(headers, "x-log-compresstype:lz4");
+            }
+
+            sds headerHost = sdsnewEmpty(128);
+            headerHost = sdscatprintf(headerHost, "Host:%s.%s", project, endpoint);
+            headers=cur_slist_append(headers, headerHost);
+
+            sds headerLen = sdsnewEmpty(64);
+            headerLen = sdscatprintf(headerLen, "Content-Length:%d", (int)buffer->length);
+            headers=cur_slist_append(headers, headerLen);
+
+            sds headerRawLen = sdsnewEmpty(64);
+            headerRawLen = sdscatprintf(headerRawLen, "x-log-bodyrawsize:%d", (int)buffer->raw_length);
+            headers=cur_slist_append(headers, headerRawLen);
+
+            sds headerTime = sdsnew("Date:");
+            headerTime = sdscat(headerTime, nowTime);
+            headers=cur_slist_append(headers, headerTime);
+
+            sds headerMD5 = sdsnew("Content-MD5:");
+            headerMD5 = sdscat(headerMD5, md5Buf);
+            headers=cur_slist_append(headers, headerMD5);
+
+            // Authorization: Bearer <api-key>
+            sds headerAuth = sdsnewEmpty(256);
+            headerAuth = sdscatprintf(headerAuth, "Authorization:Bearer %s", config->apiKey);
+            headers=cur_slist_append(headers, headerAuth);
+
+            sdsfree(headerHost);
+            sdsfree(headerLen);
+            sdsfree(headerRawLen);
+            sdsfree(headerTime);
+            sdsfree(headerMD5);
+            sdsfree(headerAuth);
+        }
+        else
+        {
         headers=cur_slist_append(headers, "x-log-apiversion:0.6.0");
         if (lz4Flag)
         {
@@ -623,6 +672,14 @@ post_log_result * post_logs_from_lz4buf_with_config(log_producer_config *config,
 //        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, (void *)buffer->data);
 //        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, buffer->length);
 
+        sdsfree(headerTime);
+        sdsfree(headerMD5);
+        sdsfree(headerLen);
+        sdsfree(headerRawLen);
+        sdsfree(headerHost);
+        sdsfree(sigContent);
+        sdsfree(headerSig);
+        } // end of AK mode auth block
 
         sds req = sdsnewEmpty(64);
         sds err = sdsnew("n/a");
@@ -652,13 +709,6 @@ post_log_result * post_logs_from_lz4buf_with_config(log_producer_config *config,
 
         cur_slist_free_all(headers); /* free the list again */
         sdsfree(url);
-        sdsfree(headerTime);
-        sdsfree(headerMD5);
-        sdsfree(headerLen);
-        sdsfree(headerRawLen);
-        sdsfree(headerHost);
-        sdsfree(sigContent);
-        sdsfree(headerSig);
         free(dest_count);
     }
 

--- a/src/log_api.h
+++ b/src/log_api.h
@@ -20,6 +20,7 @@ struct _log_post_option
   int ntp_time_offset; //time offset between local time and server time
   int using_https; // 0 http, 1 https
   int mode; // 0, LoadBalance; 1 KeyShard
+  int auth_version; // AUTH_VERSION_1 or AUTH_VERSION_APIKEY
   char *shardKey;
 };
 typedef struct _log_post_option log_post_option;

--- a/src/log_define.h
+++ b/src/log_define.h
@@ -33,5 +33,12 @@ struct _post_log_result
 
 typedef struct _post_log_result post_log_result;
 
+enum _auth_version
+{
+    AUTH_VERSION_1 = 1,
+    AUTH_VERSION_APIKEY   // API-Key Bearer token auth
+};
+
+typedef enum _auth_version auth_version;
 
 #endif

--- a/src/log_producer_config.c
+++ b/src/log_producer_config.c
@@ -61,6 +61,7 @@ log_producer_config * create_log_producer_config()
     log_producer_config* pConfig = (log_producer_config*)malloc(sizeof(log_producer_config));
     memset(pConfig, 0, sizeof(log_producer_config));
     _set_default_producer_config(pConfig);
+    pConfig->securityTokenLock = CreateCriticalSection();
     return pConfig;
 }
 
@@ -593,10 +594,40 @@ void log_producer_config_set_shardkey(log_producer_config *config, const char *s
 
 void log_producer_config_set_api_key(log_producer_config * config, const char * api_key)
 {
+    if (config == NULL || api_key == NULL || api_key[0] == '\0')
+    {
+        return;
+    }
+    CS_ENTER(config->securityTokenLock);
+    _copy_config_string(api_key, &config->apiKey);
+    config->authVersion = AUTH_VERSION_APIKEY;
+    CS_LEAVE(config->securityTokenLock);
+}
+
+void log_producer_config_reset_api_key(log_producer_config * config, const char * api_key)
+{
+    if (config == NULL || api_key == NULL || api_key[0] == '\0')
+    {
+        return;
+    }
+    CS_ENTER(config->securityTokenLock);
+    if (config->authVersion != AUTH_VERSION_APIKEY)
+    {
+        CS_LEAVE(config->securityTokenLock);
+        aos_error_log("reset api-key requires AUTH_VERSION_APIKEY mode");
+        return;
+    }
+    _copy_config_string(api_key, &config->apiKey);
+    CS_LEAVE(config->securityTokenLock);
+}
+
+void log_producer_config_get_api_key(log_producer_config * config, char ** api_key)
+{
     if (config == NULL || api_key == NULL)
     {
         return;
     }
-    _copy_config_string(api_key, &config->apiKey);
-    config->authVersion = AUTH_VERSION_APIKEY;
+    CS_ENTER(config->securityTokenLock);
+    _copy_config_string(config->apiKey, api_key);
+    CS_LEAVE(config->securityTokenLock);
 }

--- a/src/log_producer_config.c
+++ b/src/log_producer_config.c
@@ -61,7 +61,6 @@ log_producer_config * create_log_producer_config()
     log_producer_config* pConfig = (log_producer_config*)malloc(sizeof(log_producer_config));
     memset(pConfig, 0, sizeof(log_producer_config));
     _set_default_producer_config(pConfig);
-    pConfig->securityTokenLock = CreateCriticalSection();
     return pConfig;
 }
 
@@ -598,6 +597,10 @@ void log_producer_config_set_api_key(log_producer_config * config, const char * 
     {
         return;
     }
+    if (config->securityTokenLock == NULL)
+    {
+        config->securityTokenLock = CreateCriticalSection();
+    }
     CS_ENTER(config->securityTokenLock);
     _copy_config_string(api_key, &config->apiKey);
     config->authVersion = AUTH_VERSION_APIKEY;
@@ -608,6 +611,11 @@ void log_producer_config_reset_api_key(log_producer_config * config, const char 
 {
     if (config == NULL || api_key == NULL || api_key[0] == '\0')
     {
+        return;
+    }
+    if (config->securityTokenLock == NULL)
+    {
+        aos_error_log("reset api-key requires initialized API-Key mode");
         return;
     }
     CS_ENTER(config->securityTokenLock);
@@ -625,6 +633,11 @@ void log_producer_config_get_api_key(log_producer_config * config, char ** api_k
 {
     if (config == NULL || api_key == NULL)
     {
+        return;
+    }
+    if (config->securityTokenLock == NULL)
+    {
+        _copy_config_string(config->apiKey, api_key);
         return;
     }
     CS_ENTER(config->securityTokenLock);

--- a/src/log_producer_config.c
+++ b/src/log_producer_config.c
@@ -24,6 +24,7 @@ static void _set_default_producer_config(log_producer_config * pConfig)
     pConfig->compressType = 1;
     pConfig->ntpTimeOffset = 0;
     pConfig->using_https = 0;
+    pConfig->authVersion = AUTH_VERSION_1;
     pConfig->maxLogDelayTime = 7*24*3600;
     pConfig->dropDelayLog = 1;
     pConfig->callbackFromSenderThread = 1;
@@ -122,6 +123,10 @@ void destroy_log_producer_config(log_producer_config * pConfig)
     }
     if (pConfig->mode == 1 && NULL != pConfig->shardKey) {
         sdsfree(pConfig->shardKey);
+    }
+    if (pConfig->apiKey != NULL)
+    {
+        sdsfree(pConfig->apiKey);
     }
     free(pConfig);
 }
@@ -402,10 +407,38 @@ int log_producer_config_is_valid(log_producer_config * config)
         aos_error_log("invalid producer config destination params");
 //        return 0;
     }
-    if (config->accessKey == NULL || config->accessKeyId == NULL)
+
+    // API-Key mode validation
+    if (config->authVersion == AUTH_VERSION_APIKEY)
     {
-        aos_error_log("invalid producer config authority params");
-//        return 0;
+        if (config->accessKeyId != NULL || config->accessKey != NULL)
+        {
+            aos_error_log("api-key mode is mutually exclusive with access-key mode");
+            return 0;
+        }
+        if (config->using_https != 1)
+        {
+            aos_error_log("api-key mode requires HTTPS");
+            return 0;
+        }
+        if (config->apiKey == NULL || strlen(config->apiKey) == 0)
+        {
+            aos_error_log("api-key mode requires a non-empty api-key");
+            return 0;
+        }
+    }
+    else
+    {
+        if (config->apiKey != NULL)
+        {
+            aos_error_log("apiKey is set but authVersion is not AUTH_VERSION_APIKEY, conflict");
+            return 0;
+        }
+        if (config->accessKey == NULL || config->accessKeyId == NULL)
+        {
+            aos_error_log("invalid producer config authority params");
+//            return 0;
+        }
     }
     if (config->packageTimeoutInMS < 0 || config->maxBufferBytes < 0 || config->logCountPerPackage < 0 || config->logBytesPerPackage < 0)
     {
@@ -556,4 +589,14 @@ void log_producer_config_set_shardkey(log_producer_config *config, const char *s
     }
 
     _copy_config_string(shardKey, &config->shardKey);
+}
+
+void log_producer_config_set_api_key(log_producer_config * config, const char * api_key)
+{
+    if (config == NULL || api_key == NULL)
+    {
+        return;
+    }
+    _copy_config_string(api_key, &config->apiKey);
+    config->authVersion = AUTH_VERSION_APIKEY;
 }

--- a/src/log_producer_config.h
+++ b/src/log_producer_config.h
@@ -35,6 +35,7 @@ typedef struct _log_producer_config
     char * securityToken;
     char * topic;
     char * source;
+    // Shared lock for AK/STS and API-Key credential snapshots.
     CRITICALSECTION securityTokenLock;
     log_producer_config_tag * tags;
     int32_t tagAllocSize;
@@ -390,10 +391,22 @@ LOG_EXPORT int log_producer_persistent_config_is_enabled(log_producer_config * c
  * @note api-key mode is mutually exclusive with access-key mode
  * @note api-key mode requires HTTPS, otherwise config validation will fail
  * @note this will automatically set authVersion to AUTH_VERSION_APIKEY
+ * @note call this before create_log_producer; use reset_api_key for runtime rotation
  * @param config
  * @param api_key the API-Key string
  */
 LOG_EXPORT void log_producer_config_set_api_key(log_producer_config * config, const char * api_key);
+
+/**
+ * reset API-Key while producer is running (thread safe)
+ * @note config must already be in AUTH_VERSION_APIKEY mode
+ */
+LOG_EXPORT void log_producer_config_reset_api_key(log_producer_config * config, const char * api_key);
+
+/**
+ * inner api: copy the current API-Key under the shared credential lock
+ */
+LOG_EXPORT void log_producer_config_get_api_key(log_producer_config * config, char ** api_key);
 
 
 LOG_CPP_END

--- a/src/log_producer_config.h
+++ b/src/log_producer_config.h
@@ -58,6 +58,10 @@ typedef struct _log_producer_config
     int32_t compressType; // 0 no compress, 1 lz4
     int32_t ntpTimeOffset;
     int using_https; // 0 http, 1 https
+    auth_version authVersion;
+
+    // API-Key authentication (mutually exclusive with accessKeyId/accessKey)
+    char * apiKey;
 
     // for persistent feature
     int32_t usePersistent; // 0 no, 1 yes
@@ -380,6 +384,16 @@ LOG_EXPORT int log_producer_config_is_valid(log_producer_config * config);
  * @return
  */
 LOG_EXPORT int log_producer_persistent_config_is_enabled(log_producer_config * config);
+
+/**
+ * set producer config api-key for API-Key authentication mode
+ * @note api-key mode is mutually exclusive with access-key mode
+ * @note api-key mode requires HTTPS, otherwise config validation will fail
+ * @note this will automatically set authVersion to AUTH_VERSION_APIKEY
+ * @param config
+ * @param api_key the API-Key string
+ */
+LOG_EXPORT void log_producer_config_set_api_key(log_producer_config * config, const char * api_key);
 
 
 LOG_CPP_END

--- a/src/log_producer_sender.c
+++ b/src/log_producer_sender.c
@@ -211,6 +211,7 @@ void * log_producer_send_fun(void * param)
         option.ntp_time_offset = config->ntpTimeOffset;
         option.mode = config->mode;
         option.shardKey = config->shardKey;
+        option.auth_version = config->authVersion;
         post_log_result * rst;
         if (config->webTracking)
         {
@@ -222,7 +223,15 @@ void * log_producer_send_fun(void * param)
             sds accessKeyId = NULL;
             sds accessKey = NULL;
             sds stsToken = NULL;
-            log_producer_config_get_security(config, &accessKeyId, &accessKey, &stsToken);
+            if (config->authVersion == AUTH_VERSION_APIKEY)
+            {
+                // API-Key mode: pass apiKey as accessKeyId, no accessKey/stsToken needed
+                accessKeyId = sdsnew(config->apiKey);
+            }
+            else
+            {
+                log_producer_config_get_security(config, &accessKeyId, &accessKey, &stsToken);
+            }
             rst = post_logs_from_lz4buf_with_config(config, config->endpoint, config->project, config->logstore, accessKeyId, accessKey, stsToken, send_buf, &option);
             sdsfree(accessKeyId);
             sdsfree(accessKey);

--- a/src/log_producer_sender.c
+++ b/src/log_producer_sender.c
@@ -225,8 +225,8 @@ void * log_producer_send_fun(void * param)
             sds stsToken = NULL;
             if (config->authVersion == AUTH_VERSION_APIKEY)
             {
-                // API-Key mode: pass apiKey as accessKeyId, no accessKey/stsToken needed
-                accessKeyId = sdsnew(config->apiKey);
+                // API-Key mode: copy a request-scoped snapshot under the shared credential lock.
+                log_producer_config_get_api_key(config, &accessKeyId);
             }
             else
             {
@@ -551,5 +551,4 @@ log_producer_send_param * create_log_producer_send_param(log_producer_config * p
     }
     return param;
 }
-
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+find_package(Threads)
+if(CMAKE_USE_PTHREADS_INIT)
+    include_directories(${CMAKE_SOURCE_DIR}/src)
+    add_executable(api_key_rotation_test api_key_rotation_test.c)
+    target_link_libraries(api_key_rotation_test log_c_sdk_static ${CMAKE_THREAD_LIBS_INIT})
+    add_test(NAME api_key_rotation_test COMMAND api_key_rotation_test)
+endif()

--- a/tests/api_key_rotation_test.c
+++ b/tests/api_key_rotation_test.c
@@ -1,0 +1,93 @@
+#include "log_producer_config.h"
+#include "sds.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <string.h>
+
+#define ROTATION_COUNT 10000
+#define READER_COUNT 4
+
+static const char * API_KEY_INITIAL = "api-key-initial-00000000000000000000";
+static const char * API_KEY_A = "api-key-a-aaaaaaaaaaaaaaaaaaaaaaaa";
+static const char * API_KEY_B = "api-key-b-bbbbbbbbbbbbbbbbbbbbbbbb";
+
+typedef struct _rotation_context
+{
+    log_producer_config * config;
+} rotation_context;
+
+static int is_expected_key(const char * api_key)
+{
+    return strcmp(api_key, API_KEY_INITIAL) == 0
+        || strcmp(api_key, API_KEY_A) == 0
+        || strcmp(api_key, API_KEY_B) == 0;
+}
+
+static void * rotate_api_key(void * userdata)
+{
+    rotation_context * context = (rotation_context *)userdata;
+    int i = 0;
+    for (; i < ROTATION_COUNT; ++i)
+    {
+        log_producer_config_reset_api_key(context->config, i % 2 == 0 ? API_KEY_A : API_KEY_B);
+    }
+    return NULL;
+}
+
+static void * read_api_key(void * userdata)
+{
+    rotation_context * context = (rotation_context *)userdata;
+    int i = 0;
+    for (; i < ROTATION_COUNT; ++i)
+    {
+        sds api_key = NULL;
+        log_producer_config_get_api_key(context->config, &api_key);
+        if (api_key == NULL || !is_expected_key(api_key))
+        {
+            sdsfree(api_key);
+            return (void *)1;
+        }
+        sdsfree(api_key);
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    log_producer_config * config = create_log_producer_config();
+    rotation_context context;
+    sds in_flight_snapshot = NULL;
+    sds rotated_snapshot = NULL;
+    pthread_t writer;
+    pthread_t readers[READER_COUNT];
+    int i = 0;
+
+    assert(config != NULL);
+    log_producer_config_set_api_key(config, API_KEY_INITIAL);
+    log_producer_config_get_api_key(config, &in_flight_snapshot);
+    log_producer_config_reset_api_key(config, API_KEY_A);
+    log_producer_config_get_api_key(config, &rotated_snapshot);
+    assert(strcmp(in_flight_snapshot, API_KEY_INITIAL) == 0);
+    assert(strcmp(rotated_snapshot, API_KEY_A) == 0);
+    sdsfree(in_flight_snapshot);
+    sdsfree(rotated_snapshot);
+    context.config = config;
+
+    assert(pthread_create(&writer, NULL, rotate_api_key, &context) == 0);
+    for (; i < READER_COUNT; ++i)
+    {
+        assert(pthread_create(&readers[i], NULL, read_api_key, &context) == 0);
+    }
+
+    assert(pthread_join(writer, NULL) == 0);
+    for (i = 0; i < READER_COUNT; ++i)
+    {
+        void * result = NULL;
+        assert(pthread_join(readers[i], &result) == 0);
+        assert(result == NULL);
+    }
+
+    destroy_log_producer_config(config);
+    return 0;
+}

--- a/tests/api_key_rotation_test.c
+++ b/tests/api_key_rotation_test.c
@@ -55,16 +55,35 @@ static void * read_api_key(void * userdata)
 
 int main(void)
 {
+    log_producer_config * static_ak_config = create_log_producer_config();
     log_producer_config * config = create_log_producer_config();
     rotation_context context;
+    sds access_key_id = NULL;
+    sds access_key_secret = NULL;
+    sds security_token = NULL;
     sds in_flight_snapshot = NULL;
     sds rotated_snapshot = NULL;
     pthread_t writer;
     pthread_t readers[READER_COUNT];
     int i = 0;
 
+    assert(static_ak_config != NULL);
+    assert(static_ak_config->securityTokenLock == NULL);
+    log_producer_config_set_access_id(static_ak_config, "test-access-key-id");
+    log_producer_config_set_access_key(static_ak_config, "test-access-key-secret");
+    log_producer_config_get_security(static_ak_config, &access_key_id, &access_key_secret, &security_token);
+    assert(static_ak_config->securityTokenLock == NULL);
+    assert(strcmp(access_key_id, "test-access-key-id") == 0);
+    assert(strcmp(access_key_secret, "test-access-key-secret") == 0);
+    sdsfree(access_key_id);
+    sdsfree(access_key_secret);
+    sdsfree(security_token);
+    destroy_log_producer_config(static_ak_config);
+
     assert(config != NULL);
+    assert(config->securityTokenLock == NULL);
     log_producer_config_set_api_key(config, API_KEY_INITIAL);
+    assert(config->securityTokenLock != NULL);
     log_producer_config_get_api_key(config, &in_flight_snapshot);
     log_producer_config_reset_api_key(config, API_KEY_A);
     log_producer_config_get_api_key(config, &rotated_snapshot);


### PR DESCRIPTION
## Summary

Add API-Key Bearer token authentication as an alternative to AccessKey (HMAC-SHA1) mode for the **persistent** branch.

## Changes

### Core
- `src/log_define.h`: Add `auth_version` enum (`AUTH_VERSION_1`, `AUTH_VERSION_APIKEY`)
- `src/log_producer_config.h/c`: Add `authVersion`, `apiKey` fields; add `log_producer_config_set_api_key()` setter; add API-Key validation in `is_valid()`
- `src/log_api.h`: Add `auth_version` to `log_post_option`
- `src/log_api.c`: Skip AK pre-check for API-Key mode in `post_logs_from_lz4buf_with_config()`; add Bearer token auth branch using `cur_slist` HTTP abstraction layer
- `src/log_producer_sender.c`: Pass `auth_version` from config; skip AK credential retrieval in API-Key mode

### Documentation
- `docs/cn/ApiKeyAuth.md`: Chinese API-Key authentication guide (with persistent storage examples)
- `docs/en/ApiKeyAuth.md`: English API-Key authentication guide (with persistent storage examples)

## Key Design
- API-Key mode sends `Authorization: Bearer <api-key>` header (no signature computation)
- Mutually exclusive with AccessKey mode (validated at config level)
- HTTPS is mandatory for API-Key mode (validated at config level)
- Fully compatible with persistent storage feature (credentials not persisted to disk)
- Adapts to persistent branch's `cur_slist` / `LOG_OS_HttpPost` HTTP abstraction layer
- Compilation verified on macOS