### PR TITLE
feat(live): add HTTPS support

### DIFF
--- a/src/log_api.c
+++ b/src/log_api.c
@@ -235,7 +235,12 @@ post_log_result * post_logs_from_lz4buf(const char *endpoint, const char * acces
     if (curl != NULL)
     {
         // url
-        sds url = sdsnew("http://");
+        sds url = NULL;
+        if (option != NULL && option->using_https) {
+            url = sdsnew("https://");
+        } else {
+            url = sdsnew("http://");
+        }
         url = sdscat(url, project);
         url = sdscat(url, ".");
         url = sdscat(url, endpoint);

--- a/src/log_api.h
+++ b/src/log_api.h
@@ -17,6 +17,7 @@ struct _log_post_option
   int operation_timeout; // operation timeout seconds, 0 as default
   int compress_type; // 0 no compress, 1 lz4
   int ntp_time_offset; //time offset between local time and server time
+  int using_https; // 0 http, 1 https
 };
 typedef struct _log_post_option log_post_option;
 

--- a/src/log_producer_config.c
+++ b/src/log_producer_config.c
@@ -21,6 +21,7 @@ static void _set_default_producer_config(log_producer_config * pConfig)
     pConfig->destroyFlusherWaitTimeoutSec = 1;
     pConfig->compressType = 1;
     pConfig->ntpTimeOffset = 0;
+    pConfig->using_https = 0;
 }
 
 
@@ -280,12 +281,16 @@ void log_producer_config_add_tag(log_producer_config * pConfig, const char * key
 
 void log_producer_config_set_endpoint(log_producer_config * config, const char * endpoint)
 {
-    if (strncmp(endpoint, "http://", 7) == 0)
+    if (strlen(endpoint) < 8) {
+        return;
+    }
+        if (strncmp(endpoint, "http://", 7) == 0)
     {
         endpoint += 7;
     }
     else if (strncmp(endpoint, "https://", 8) == 0)
     {
+        config->using_https = 1;
         endpoint += 8;
     }
     _copy_config_string(endpoint, &config->endpoint);
@@ -373,4 +378,13 @@ int log_producer_config_is_valid(log_producer_config * config)
         return 0;
     }
     return 1;
+}
+
+void log_producer_config_set_using_http(log_producer_config * config, int32_t using_https)
+{
+    if (config == NULL || using_https < 0)
+    {
+        return;
+    }
+    config->using_https = using_https;
 }

--- a/src/log_producer_config.h
+++ b/src/log_producer_config.h
@@ -51,6 +51,7 @@ typedef struct _log_producer_config
 
     int32_t compressType; // 0 no compress, 1 lz4
     int32_t ntpTimeOffset;
+    int32_t using_https; // 0 http, 1 https
 }log_producer_config;
 
 
@@ -251,7 +252,12 @@ void log_producer_config_print(log_producer_config * config, FILE * pFile);
  */
 LOG_EXPORT int log_producer_config_is_valid(log_producer_config * config);
 
-
+/**
+ * set producer config using https, default http
+ * @param config
+ * @param using_https 0 http, 1 https
+ */
+LOG_EXPORT void log_producer_config_set_using_http(log_producer_config * config, int32_t using_https);
 
 LOG_CPP_END
 

--- a/src/log_producer_sender.c
+++ b/src/log_producer_sender.c
@@ -158,6 +158,7 @@ void * log_producer_send_fun(void * param)
         option.interface = config->netInterface;
         option.compress_type = config->compressType;
         option.ntp_time_offset = config->ntpTimeOffset;
+        option.using_https = config->using_https;
         sds accessKeyId = NULL;
         sds accessKey = NULL;
         sds stsToken = NULL;


### PR DESCRIPTION
## Summary

Add HTTPS transport support for the live branch (aligned with master and persistent branches).

## Changes

- Add `using_https` field to `log_producer_config` struct (default 0 = HTTP)
- Add `using_https` field to `log_post_option` struct
- Auto-detect `https://` prefix in `log_producer_config_set_endpoint()`
- Add `log_producer_config_set_using_http()` setter for explicit control
- Use `option->using_https` to select URL scheme (`https://` vs `http://`) in `post_logs_from_lz4buf()`
- Pass `config->using_https` to option in sender

## Usage

```c
// Auto-detect from endpoint URL
log_producer_config_set_endpoint(config, "https://cn-hangzhou.log.aliyuncs.com");

// Or set explicitly
log_producer_config_set_using_http(config, 1);
```
